### PR TITLE
Restore client in `extension.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lint": "eslint src --ext ts",
     "typecheck": "tsc --noEmit",
     "package": "webpack --mode production --devtool source-map --config ./webpack.config.js",
+    "watch": "webpack --watch",
     "vsce-package": "vsce package -o ruff.vsix",
     "vscode:prepublish": "npm run package"
   },

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -112,11 +112,11 @@ export async function restartServer(
   serverId: string,
   serverName: string,
   outputChannel: OutputChannel,
-  lsClient?: LanguageClient,
+  client?: LanguageClient,
 ): Promise<LanguageClient | undefined> {
-  if (lsClient) {
+  if (client) {
     traceInfo(`Server: Stop requested`);
-    await lsClient.stop();
+    await client.stop();
     _disposables.forEach((d) => d.dispose());
     _disposables = [];
   }
@@ -132,7 +132,7 @@ export async function restartServer(
     return undefined;
   }
 
-  const newLSClient = await createServer(
+  const newClient = await createServer(
     resourceSettings.interpreter,
     serverId,
     serverName,
@@ -144,10 +144,10 @@ export async function restartServer(
     resourceSettings,
   );
 
-  newLSClient.trace = traceLevelToLSTrace(resourceSettings.logLevel);
+  newClient.trace = traceLevelToLSTrace(resourceSettings.logLevel);
   traceInfo(`Server: Start requested.`);
   _disposables.push(
-    newLSClient.onDidChangeState((e) => {
+    newClient.onDidChangeState((e) => {
       switch (e.newState) {
         case State.Stopped:
           traceVerbose(`Server State: Stopped`);
@@ -160,7 +160,7 @@ export async function restartServer(
           break;
       }
     }),
-    newLSClient.start(),
+    newClient.start(),
   );
-  return newLSClient;
+  return newClient;
 }


### PR DESCRIPTION
## Summary

In #194, we stopped setting the `client` returned by the `clientPromise`. As a result, the "Fix all" action stopped working, since it relies on the `client`.

Closes #194.
