### PR TITLE
Fix links to canonical repository URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,81 +36,81 @@ See [here](https://github.com/charliermarsh/ruff/releases) for the Ruff release 
 
 ## 2022.0.22 (14 December 2022)
 
-- Fix 'Exception ignored in atexit callback' in jsonrpc by @eddyg in https://github.com/charliermarsh/vscode-ruff/pull/54
-- Mark unused imports and local variables as unnecessary by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/55
-- Bump Ruff version to 0.0.182 by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/57
+- Fix 'Exception ignored in atexit callback' in jsonrpc by @eddyg in https://github.com/astral-sh/ruff-vscode/pull/54
+- Mark unused imports and local variables as unnecessary by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/55
+- Bump Ruff version to 0.0.182 by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/57
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.21...2022.0.22
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.21...2022.0.22
 
 ## 2022.0.21 (6 December 2022)
 
-- Bump Ruff version to 0.0.165 by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/52
+- Bump Ruff version to 0.0.165 by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/52
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.20...2022.0.21
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.20...2022.0.21
 
 ## 2022.0.20 (1 December 2022)
 
-- Bump default line length by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/46
-- Enable CI by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/47
-- Delay import of typing_extensions by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/49
+- Bump default line length by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/46
+- Enable CI by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/47
+- Delay import of typing_extensions by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/49
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.19...2022.0.20
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.19...2022.0.20
 
 ## 2022.0.19 (1 December 2022)
 
-- Restore Python 3.7 compatibility by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/44
+- Restore Python 3.7 compatibility by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/44
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.18...2022.0.19
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.18...2022.0.19
 
 ## 2022.0.18 (1 December 2022)
 
-- Enable `ruff: Organize Imports` action by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/32
-- Bump Ruff version to 0.0.149 by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/33
-- Fix failing lint test by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/34
-- Fix mypy by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/35
-- Remove pylint ignore directives by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/36
-- Add name and version to LanguageServer by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/38
-- Upgrade to pygls==1.0.0a3 by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/37
-- Bump Ruff version to 0.0.150 by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/40
-- Implement code actions for Ruff autofix by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/39
-- Update noxfile and fix lint errors by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/41
-- Add diagnostic code to Quickfix by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/42
+- Enable `ruff: Organize Imports` action by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/32
+- Bump Ruff version to 0.0.149 by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/33
+- Fix failing lint test by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/34
+- Fix mypy by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/35
+- Remove pylint ignore directives by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/36
+- Add name and version to LanguageServer by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/38
+- Upgrade to pygls==1.0.0a3 by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/37
+- Bump Ruff version to 0.0.150 by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/40
+- Implement code actions for Ruff autofix by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/39
+- Update noxfile and fix lint errors by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/41
+- Add diagnostic code to Quickfix by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/42
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.17...2022.0.18
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.17...2022.0.18
 
 ## 2022.0.17 (25 November 2022)
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.16...2022.0.17
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.16...2022.0.17
 
 ## 2022.0.16 (25 November 2022)
 
-- Publish to OpenVSX by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/30
-- Bump Ruff version to 0.0.138 by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/31
+- Publish to OpenVSX by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/30
+- Bump Ruff version to 0.0.138 by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/31
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.15...2022.0.16
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.15...2022.0.16
 
 ## 2022.0.15 (20 November 2022)
 
-- Bump Ruff version to 0.0.132 by @charliermarsh in https://github.com/charliermarsh/vscode-ruff/pull/27
-- add changelog.md by @akanz1 in https://github.com/charliermarsh/vscode-ruff/pull/24
+- Bump Ruff version to 0.0.132 by @charliermarsh in https://github.com/astral-sh/ruff-vscode/pull/27
+- add changelog.md by @akanz1 in https://github.com/astral-sh/ruff-vscode/pull/24
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.14...2022.0.15
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.14...2022.0.15
 
 ## 2022.0.14 (15 November 2022)
 
-- Update README.md by @akanz1 in [#21](https://github.com/charliermarsh/vscode-ruff/pull/21)
-- Bump Ruff version to 0.0.121 by @charliermarsh in [#22](https://github.com/charliermarsh/vscode-ruff/pull/22)
-- Bump version to 2022.0.14 by @charliermarsh in [#23](https://github.com/charliermarsh/vscode-ruff/pull/23)
+- Update README.md by @akanz1 in [#21](https://github.com/astral-sh/ruff-vscode/pull/21)
+- Bump Ruff version to 0.0.121 by @charliermarsh in [#22](https://github.com/astral-sh/ruff-vscode/pull/22)
+- Bump version to 2022.0.14 by @charliermarsh in [#23](https://github.com/astral-sh/ruff-vscode/pull/23)
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.13...2022.0.14
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.13...2022.0.14
 
 ## 2022.0.13 (13 November 2022)
 
-- Use scripts path when interpreter is set by @charliermarsh in [#18](https://github.com/charliermarsh/vscode-ruff/pull/18)
-- Bump Ruff version to 0.0.117 by @charliermarsh in [#19](https://github.com/charliermarsh/vscode-ruff/pull/19)
+- Use scripts path when interpreter is set by @charliermarsh in [#18](https://github.com/astral-sh/ruff-vscode/pull/18)
+- Bump Ruff version to 0.0.117 by @charliermarsh in [#19](https://github.com/astral-sh/ruff-vscode/pull/19)
 
-**Full Changelog**: https://github.com/charliermarsh/vscode-ruff/compare/2022.0.12...2022.0.13
+**Full Changelog**: https://github.com/astral-sh/ruff-vscode/compare/2022.0.12...2022.0.13
 
 ## 2022.0.12 (11 November 2022)
 
-- Add .idea and .ruff_cache to .vscodeignore by @charliermarsh in [#14](https://github.com/charliermarsh/vscode-ruff/pull/14)
+- Add .idea and .ruff_cache to .vscodeignore by @charliermarsh in [#14](https://github.com/astral-sh/ruff-vscode/pull/14)

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "publisher": "charliermarsh",
   "license": "MIT",
-  "homepage": "https://github.com/astral-sh/vscode-ruff",
+  "homepage": "https://github.com/astral-sh/ruff-vscode",
   "repository": {
     "type": "git",
-    "url": "https://github.com/astral-sh/vscode-ruff.git"
+    "url": "https://github.com/astral-sh/ruff-vscode.git"
   },
   "bugs": {
-    "url": "https://github.com/astral-sh/vscode-ruff/issues"
+    "url": "https://github.com/astral-sh/ruff-vscode/issues"
   },
   "icon": "icon.png",
   "galleryBanner": {


### PR DESCRIPTION
## Summary

Simple fix to the new canonical URL of the `ruff-vscode` project.

## Test Plan

I clicked them all! 😁
