### PR TITLE
Remove unused showNotifications setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,24 +137,6 @@
           ],
           "default": "off",
           "markdownDescription": "Traces the communication between VSCode and the ruff-lsp."
-        },
-        "ruff.showNotifications": {
-          "default": "off",
-          "description": "Controls when notifications are shown by this extension.",
-          "enum": [
-            "off",
-            "onError",
-            "onWarning",
-            "always"
-          ],
-          "enumDescriptions": [
-            "All notifications are turned off, any errors or warning are still available in the logs.",
-            "Notifications are shown only in the case of an error.",
-            "Notifications are shown for errors and warnings.",
-            "Notifications are show for anything that the server chooses to show."
-          ],
-          "scope": "machine",
-          "type": "string"
         }
       }
     },

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -41,9 +41,6 @@ async function createServer(
     newEnv.USE_DEBUGPY = "False";
   }
 
-  // Set notification type
-  newEnv.LS_SHOW_NOTIFICATION = settings.showNotifications;
-
   const args =
     newEnv.USE_DEBUGPY === "False" || !isDebugScript
       ? settings.interpreter.slice(1).concat([SERVER_SCRIPT_PATH])

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -21,7 +21,6 @@ export interface ISettings {
   importStrategy: ImportStrategy;
   run: Run;
   enable: boolean;
-  showNotifications: string;
   organizeImports: boolean;
   fixAll: boolean;
 }
@@ -83,7 +82,6 @@ export async function getWorkspaceSettings(
     enable: config.get<boolean>(`enable`) ?? true,
     organizeImports: config.get<boolean>(`organizeImports`) ?? true,
     fixAll: config.get<boolean>(`fixAll`) ?? true,
-    showNotifications: config.get<string>(`showNotifications`) ?? "off",
   };
 }
 
@@ -105,7 +103,6 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     enable: getGlobalValue<boolean>(config, `enable`, true),
     organizeImports: getGlobalValue<boolean>(config, `organizeImports`, true),
     fixAll: getGlobalValue<boolean>(config, `fixAll`, true),
-    showNotifications: getGlobalValue<string>(config, "showNotifications", "off"),
   };
 }
 
@@ -122,7 +119,6 @@ export function checkIfConfigurationChanged(
     `${namespace}.enable`,
     `${namespace}.organizeImports`,
     `${namespace}.fixAll`,
-    `${namespace}.showNotifications`,
   ];
   return settings.some((s) => e.affectsConfiguration(s));
 }


### PR DESCRIPTION
## Summary

It appears that the setting for `showNotifications` has been removed in the latest version of `ruff-lsp`. Therefore, we have also removed it on the `ruff-vscode` side.

- <https://github.com/astral-sh/ruff-lsp/pull/149>

## Test Plan

The following command has been executed/completed.

- `just fmt`
- `just check`
- `just test`
