### PR TITLE
Add a VS Code setting to enable the experimental formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,12 @@
           ],
           "scope": "machine",
           "type": "string"
+        },
+        "ruff.enableExperimentalFormatter": {
+          "default": false,
+          "markdownDescription": "Controls whether Ruff registers as capable of code formatting. The Ruff formatter is in an alpha state during which formatting may change at any time.",
+          "scope": "machine",
+          "type": "boolean"
         }
       }
     },

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -44,6 +44,11 @@ async function createServer(
   // Set notification type
   newEnv.LS_SHOW_NOTIFICATION = settings.showNotifications;
 
+  // Set experimental formatter capabilities
+  if (settings.enableExperimentalFormatter) {
+    newEnv.RUFF_EXPERIMENTAL_FORMATTER = "1";
+  }
+
   const args =
     newEnv.USE_DEBUGPY === "False" || !isDebugScript
       ? settings.interpreter.slice(1).concat([SERVER_SCRIPT_PATH])

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -31,6 +31,7 @@ export interface ISettings {
   run: Run;
   codeAction: CodeAction;
   enable: boolean;
+  enableExperimentalFormatter: boolean;
   showNotifications: string;
   organizeImports: boolean;
   fixAll: boolean;
@@ -95,6 +96,7 @@ export async function getWorkspaceSettings(
     organizeImports: config.get<boolean>("organizeImports") ?? true,
     fixAll: config.get<boolean>("fixAll") ?? true,
     showNotifications: config.get<string>("showNotifications") ?? "off",
+    enableExperimentalFormatter: config.get<boolean>("enableExperimentalFormatter") ?? false,
   };
 }
 
@@ -118,6 +120,11 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     organizeImports: getGlobalValue<boolean>(config, "organizeImports", true),
     fixAll: getGlobalValue<boolean>(config, "fixAll", true),
     showNotifications: getGlobalValue<string>(config, "showNotifications", "off"),
+    enableExperimentalFormatter: getGlobalValue<boolean>(
+      config,
+      "enableExperimentalFormatter",
+      false,
+    ),
   };
 }
 
@@ -136,6 +143,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.path`,
     `${namespace}.run`,
     `${namespace}.showNotifications`,
+    `${namespace}.enableExperimentalFormatter`,
   ];
   return settings.some((s) => e.affectsConfiguration(s));
 }


### PR DESCRIPTION
## Summary

This PR adds an `enableExperimentalFormatter` flag to the extension which turns on formatting capabilities by setting the environment variable in the LSP server. Our extension is setup such that if you change this setting, we restart the server, so it is respected across modifications. This is (intentionally) more discoverable, as I had trouble with the environment variable alone.

## Test Plan

- Run the extension locally.
- Set `"editor.defaultFormatter": "charliermarsh.ruff"` in `settings.json`.
- Try to format; verify that Ruff is not a valid option.
- Enable the setting (`"ruff.enableExperimentalFormatter": true`).
- Try to format; verify that it works as expected.
- Disable the setting; try to format; verify that it fails as expected:

<img width="1512" alt="Screen Shot 2023-09-02 at 5 23 25 PM" src="https://github.com/astral-sh/ruff-vscode/assets/1309177/87fb4bb8-41f2-4454-9787-432123a8bddb">
