### PR TITLE
allow `enableExperimentalFormatter` to be configured in the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
         "ruff.enableExperimentalFormatter": {
           "default": false,
           "markdownDescription": "Controls whether Ruff registers as capable of code formatting. The Ruff formatter is in an alpha state during which formatting may change at any time.",
-          "scope": "machine",
+          "scope": "window",
           "type": "boolean"
         }
       }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

fixes #289 

## Test Plan

verified that the setting now shows in the workspace tab:

![image](https://github.com/astral-sh/ruff-vscode/assets/57028336/f2eb7584-37c2-4c87-b96a-3d8cf116c77f)

