### PR TITLE
Move `args` and `run` settings to `lint.args` and `lint.run`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
           "default": [],
           "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#ruff.lint.args` instead.",
+          "deprecationMessage": "Deprecated: Please use ruff.lint.arg instead.",
           "items": {
             "type": "string"
           },
@@ -84,6 +85,7 @@
           "default": "onType",
           "markdownDescription": "Run Ruff on every keystroke (`onType`) or on save (`onSave`).",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#ruff.lint.run` instead.",
+          "deprecationMessage": "Deprecated: Please use ruff.lint.run instead.",
           "enum": [
             "onType",
             "onSave"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ maintainers = [
 requires-python = ">=3.7"
 license = "MIT"
 dependencies = [
+  "packaging>=23.1",
   "ruff-lsp==0.0.39",
   "ruff==0.0.291",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -62,6 +62,10 @@ mypy-extensions==1.0.0 \
     --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
     --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
     # via mypy
+packaging==23.2 \
+    --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
+    --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
+    # via ruff-vscode (./pyproject.toml)
 pygls==1.0.2 \
     --hash=sha256:6d278d29fa6559b0f7a448263c85cb64ec6e9369548b02f1a7944060848b21f9 \
     --hash=sha256:888ed63d1f650b4fc64d603d73d37545386ec533c0caac921aed80f80ea946a4

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,10 @@ lsprotocol==2023.0.0b1 \
     # via
     #   pygls
     #   ruff-lsp
+packaging==23.2 \
+    --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
+    --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
+    # via ruff-vscode (./pyproject.toml)
 pygls==1.0.2 \
     --hash=sha256:6d278d29fa6559b0f7a448263c85cb64ec6e9369548b02f1a7944060848b21f9 \
     --hash=sha256:888ed63d1f650b4fc64d603d73d37545386ec533c0caac921aed80f80ea946a4

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,19 +59,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   traceLog(`Module: ${serverInfo.module}`);
   traceVerbose(`Full Server Info: ${JSON.stringify(serverInfo)}`);
 
+  context.subscriptions.push(
+    onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration("ruff.enable")) {
+        vscode.window.showWarningMessage(
+          "To enable or disable Ruff after changing the `enable` setting, you must restart VS Code.",
+        );
+      }
+    }),
+  );
+
   const { enable } = getConfiguration(serverId) as unknown as ISettings;
   if (!enable) {
     traceLog(
       "Extension is disabled. To enable, change `ruff.enable` to `true` and restart VS Code.",
-    );
-    context.subscriptions.push(
-      onDidChangeConfiguration((event) => {
-        if (event.affectsConfiguration("ruff.enable")) {
-          traceLog(
-            "To enable or disable Ruff after changing the `enable` setting, you must restart VS Code.",
-          );
-        }
-      }),
     );
     return;
   }


### PR DESCRIPTION
## Summary

This is the peer PR to https://github.com/astral-sh/ruff-lsp/pull/255, which adds `lint.args` and `lint.run` to the VS Code extension, and deprecates `args` and `run`:

<img width="582" alt="Screen Shot 2023-10-02 at 3 07 32 PM" src="https://github.com/astral-sh/ruff-vscode/assets/1309177/68188078-ada1-4060-a8bb-3a734183f5e3">

The behavior is as follows:

- If you have `lint.run` defined in your settings, we will respect it and ignore `run`.
- Otherwise, if you have `run` defined in your settings, we will respect it.
- Otherwise, we fall back to the default value.

Confusingly, if you set `run`, VS Code _still_ doesn't show it in the visual settings UI, which is unfortunate, as one edge case here is:

- You have `run` defined.
- You set `lint.run` in the visual UI.
- (`run` is still defined in your `settings.json`, but not visible in the UI.)
- You unset `lint.run` in the visual UI.
- (VS Code then removes `lint.run` from your `settings.json`, since it now matches the default value and is unnecessary.)
- Now, you're using the old `run` setting even though it's not visible in the UI.

I'm not sure if there's a great way around this. We could consider showing a warning, but that might be somewhat intrusive?

## Test Plan

Extensive local testing 😅 
