### PR TITLE
Add a `format.args` setting to the VS Code extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,15 @@
           "scope": "window",
           "type": "string"
         },
+        "ruff.format.args": {
+          "default": [],
+          "markdownDescription": "Additional command-line arguments to pass to `ruff format`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.",
+          "items": {
+            "type": "string"
+          },
+          "scope": "resource",
+          "type": "array"
+        },
         "ruff.path": {
           "default": [],
           "markdownDescription": "Path to a custom `ruff` executable, e.g., `[\"/path/to/ruff\"]`.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -27,6 +27,10 @@ type Lint = {
   run?: Run;
 };
 
+type Format = {
+  args?: string[];
+};
+
 export interface ISettings {
   cwd: string;
   workspace: string;
@@ -40,6 +44,7 @@ export interface ISettings {
   organizeImports: boolean;
   fixAll: boolean;
   lint: Lint;
+  format: Format;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -102,6 +107,9 @@ export async function getWorkspaceSettings(
         workspace,
       ),
     },
+    format: {
+      args: resolveVariables(config.get<string[]>("format.args") ?? [], workspace),
+    },
     enable: config.get<boolean>("enable") ?? true,
     organizeImports: config.get<boolean>("organizeImports") ?? true,
     fixAll: config.get<boolean>("fixAll") ?? true,
@@ -128,6 +136,9 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
       run: getPreferredGlobalSetting<Run>("lint.run", "run", config) ?? "onType",
       args: getPreferredGlobalSetting<string[]>("lint.args", "args", config) ?? [],
     },
+    format: {
+      args: getGlobalValue<string[]>(config, "format.args", []),
+    },
     enable: getGlobalValue<boolean>(config, "enable", true),
     organizeImports: getGlobalValue<boolean>(config, "organizeImports", true),
     fixAll: getGlobalValue<boolean>(config, "fixAll", true),
@@ -153,6 +164,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.interpreter`,
     `${namespace}.lint.run`,
     `${namespace}.lint.args`,
+    `${namespace}.format.args`,
     `${namespace}.organizeImports`,
     `${namespace}.path`,
     `${namespace}.showNotifications`,


### PR DESCRIPTION
This is a peer PR to https://github.com/astral-sh/ruff-lsp/pull/258, adding `format.args` to the VS Code extension.