### PR TITLE
Add missing "s" in deprecation message

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
           "default": [],
           "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#ruff.lint.args` instead.",
-          "deprecationMessage": "Deprecated: Please use ruff.lint.arg instead.",
+          "deprecationMessage": "Deprecated: Please use ruff.lint.args instead.",
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When updating from `ruff.args` to new syntax `ruff.lint.args`, the helper message indicated to use `ruff.lint.arg` which was missing an `s` at the end, which in turn showed "Unknown Configuration Setting".

All other references to new syntax seem to be right, except for https://github.com/astral-sh/ruff-vscode/blame/be792045f904bb711e6cc29895a6d1ed8dfe0440/package.json#L68

![Screenshot 2023-10-11 at 10 42 20](https://github.com/astral-sh/ruff-vscode/assets/34400837/83cd793f-6034-4d66-8da5-6591c53137cf)
![Screenshot 2023-10-11 at 10 42 48](https://github.com/astral-sh/ruff-vscode/assets/34400837/76825b8c-d6ea-4922-ba03-f8a661a74747)


## Test Plan

<!-- How was it tested? -->
