### PR TITLE
Add register-status hooks to extension

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,5 +1,5 @@
 import * as fsapi from "fs-extra";
-import { Disposable, env, LogOutputChannel } from "vscode";
+import { Disposable, env, l10n, LanguageStatusSeverity, LogOutputChannel } from "vscode";
 import { State } from "vscode-languageclient";
 import {
   LanguageClient,
@@ -16,6 +16,7 @@ import {
   getWorkspaceSettings,
   ISettings,
 } from "./settings";
+import { updateStatus } from "./status";
 import { getLSClientTraceLevel, getProjectRoot } from "./utilities";
 import { isVirtualWorkspace } from "./vscodeapi";
 
@@ -89,6 +90,9 @@ export async function restartServer(
     _disposables.forEach((d) => d.dispose());
     _disposables = [];
   }
+
+  updateStatus(undefined, LanguageStatusSeverity.Information, true);
+
   const projectRoot = await getProjectRoot();
   const workspaceSetting = await getWorkspaceSettings(serverId, projectRoot);
 
@@ -108,6 +112,7 @@ export async function restartServer(
           break;
         case State.Running:
           traceVerbose(`Server State: Running`);
+          updateStatus(undefined, LanguageStatusSeverity.Information, false);
           break;
       }
     }),
@@ -115,6 +120,7 @@ export async function restartServer(
   try {
     await newLSClient.start();
   } catch (ex) {
+    updateStatus(l10n.t("Server failed to start."), LanguageStatusSeverity.Error);
     traceError(`Server: Start failed: ${ex}`);
     return undefined;
   }

--- a/src/common/status.ts
+++ b/src/common/status.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { LanguageStatusItem, Disposable, l10n, LanguageStatusSeverity } from "vscode";
+import { createLanguageStatusItem } from "./vscodeapi";
+import { Command } from "vscode-languageclient";
+import { getDocumentSelector } from "./utilities";
+
+let _status: LanguageStatusItem | undefined;
+export function registerLanguageStatusItem(id: string, name: string, command: string): Disposable {
+  _status = createLanguageStatusItem(id, getDocumentSelector());
+  _status.name = name;
+  _status.text = name;
+  _status.command = Command.create(l10n.t("Open logs"), command);
+
+  return {
+    dispose: () => {
+      _status?.dispose();
+      _status = undefined;
+    },
+  };
+}
+
+export function updateStatus(
+  status: string | undefined,
+  severity: LanguageStatusSeverity,
+  busy?: boolean,
+  detail?: string,
+): void {
+  if (_status) {
+    _status.text = status && status.length > 0 ? `${_status.name}: ${status}` : `${_status.name}`;
+    _status.severity = severity;
+    _status.busy = busy ?? false;
+    _status.detail = detail;
+  }
+}

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -2,7 +2,8 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import { LogLevel, Uri, WorkspaceFolder } from "vscode";
 import { Trace } from "vscode-jsonrpc/node";
-import { getWorkspaceFolders } from "./vscodeapi";
+import { DocumentSelector } from "vscode-languageclient";
+import { getWorkspaceFolders, isVirtualWorkspace } from "./vscodeapi";
 
 function logLevelToTrace(logLevel: LogLevel): Trace {
   switch (logLevel) {
@@ -63,4 +64,15 @@ export async function getProjectRoot(): Promise<WorkspaceFolder> {
     }
     return rootWorkspace;
   }
+}
+
+export function getDocumentSelector(): DocumentSelector {
+  return isVirtualWorkspace()
+    ? [{ language: "python" }]
+    : [
+        { scheme: "file", language: "python" },
+        { scheme: "untitled", language: "python" },
+        { scheme: "vscode-notebook", language: "python" },
+        { scheme: "vscode-notebook-cell", language: "python" },
+      ];
 }

--- a/src/common/vscodeapi.ts
+++ b/src/common/vscodeapi.ts
@@ -1,14 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import {
   commands,
   ConfigurationScope,
   Disposable,
+  languages,
+  LanguageStatusItem,
   LogOutputChannel,
-  Uri,
   window,
   workspace,
   WorkspaceConfiguration,
   WorkspaceFolder,
 } from "vscode";
+import { DocumentSelector } from "vscode-languageclient";
 
 export function createOutputChannel(name: string): LogOutputChannel {
   return window.createOutputChannel(name, { log: true });
@@ -41,6 +46,9 @@ export function getWorkspaceFolders(): readonly WorkspaceFolder[] {
   return workspace.workspaceFolders ?? [];
 }
 
-export function getWorkspaceFolder(uri: Uri): WorkspaceFolder | undefined {
-  return workspace.getWorkspaceFolder(uri);
+export function createLanguageStatusItem(
+  id: string,
+  selector: DocumentSelector,
+): LanguageStatusItem {
+  return languages.createLanguageStatusItem(id, selector);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
   ISettings,
 } from "./common/settings";
 import { loadServerDefaults } from "./common/setup";
+import { registerLanguageStatusItem, updateStatus } from "./common/status";
 import { getLSClientTraceLevel } from "./common/utilities";
 import {
   createOutputChannel,
@@ -136,9 +137,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     restartInProgress = false;
 
+    updateStatus(
+      vscode.l10n.t("Please select a Python interpreter."),
+      vscode.LanguageStatusSeverity.Error,
+    );
     traceError(
       "Python interpreter missing:\r\n" +
-        "[Option 1] Select python interpreter using the ms-python.python.\r\n" +
+        "[Option 1] Select Python interpreter using the ms-python.python.\r\n" +
         `[Option 2] Set an interpreter using "${serverId}.interpreter" setting.\r\n` +
         "Please use Python 3.7 or greater.",
     );
@@ -152,6 +157,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (checkIfConfigurationChanged(e, serverId)) {
         await runServer();
       }
+    }),
+    registerCommand(`${serverId}.showLogs`, async () => {
+      outputChannel.show();
     }),
     registerCommand(`${serverId}.restart`, async () => {
       await runServer();
@@ -231,6 +239,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         );
       });
     }),
+    registerLanguageStatusItem(serverId, serverName, `${serverId}.showLogs`),
   );
 
   setImmediate(async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/ruff-vscode/issues/343.

## Test Plan

Ran the VS Code extension; verified that the "Ruff: Open logs" command showed up in the Python language status menu.
