### PR TITLE
Build ARM Mac extension on M1 runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Generate Build ID (release)
@@ -62,10 +62,10 @@ jobs:
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
             arch: armv7
-          - os: macos-11
+          - os: macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64
-          - os: macos-11
+          - os: macos-latest-xlarge
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 
@@ -81,11 +81,19 @@ jobs:
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
       # Install Python dependencies (including Ruff's native binary).
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - run: python -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
-        if: ${{ !startsWith(matrix.os, 'ubuntu') || startsWith(matrix.target, 'x86_64') }}
+
+      # ARM builds on macOS, which should select Ruff's universal binary.
+      - run: arch -arm64 python -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
+        if: ${{ startsWith(matrix.os, 'macos') && startsWith(matrix.target, 'aarch64') }}
+
+      # x86_64 builds on macOS, which should select Ruff's x86_64 binary.
+      - run: arch -x86_64 python -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
+        if: ${{ startsWith(matrix.os, 'macos') && startsWith(matrix.target, 'x86_64') }}
+
+      # ARM builds on Ubuntu, which should select Ruff's ARM binary.
       - uses: uraimo/run-on-arch-action@v2
         if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.target, 'x86_64') }}
         with:
@@ -97,6 +105,10 @@ jobs:
             pip3 install -U pip
           run: |
             python3 -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
+
+      # Every other architecture, which should defer to `pip` without any special treatment.
+      - run: python -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
+        if: ${{ !startsWith(matrix.os, 'macos') && (!startsWith(matrix.os, 'ubuntu') || startsWith(matrix.target, 'x86_64')) }}
 
       # Install Node.
       - name: Install Node.js


### PR DESCRIPTION
At some point between 2023.50.0 and 2023.52.0, something changed in the GitHub Actions runners such that both the x86 and ARM mac builds starting using Ruff's x86 wheel. This breaks the extension when using the bundled Ruff on an M-series MacBook. (In 2023.50.0 and earlier, it turns out we were using the universal wheel for the x86 build too, which is okay, though not identical to what pip does on x86 machines.)

This PR forces the build pipeline to use the M-series MacBooks for macOS builds, and then sets the arch explicitly. As such, we now use universal for the ARM extension and x86 for the x86 extension.

<img width="967" alt="Screen Shot 2023-12-14 at 3 55 34 PM" src="https://github.com/astral-sh/ruff-vscode/assets/1309177/bb147b33-fd41-4afd-8acb-a6b8f292d88e">
<img width="951" alt="Screen Shot 2023-12-14 at 3 55 41 PM" src="https://github.com/astral-sh/ruff-vscode/assets/1309177/fd73042a-8d3b-431c-bb8c-e03ae0ae2fa7">

