### PR TITLE
Exclude scripts directory from extension bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,6 +20,7 @@
 justfile
 requirements-dev.txt
 requirements.txt
+scripts/
 src/
 tests/
 tsconfig.json


### PR DESCRIPTION
## Summary

Excludes `scripts/` (added in [#251](https://github.com/astral-sh/ruff-vscode/pull/251)) from the extension bundle as it is not required.

Current bundle:

```console
extension/
├─ bundled/
├─ dist/
├─ scripts/
│  ├─ bump_extension_version.sh
│  ├─ bump_lsp_version.sh
│  ├─ bump_ruff_version.sh
├─ CHANGELOG.md
├─ icon.png
├─ LICENSE.txt
├─ package.json
├─ pyproject.toml
├─ README.md
```

## Test Plan

Built the package, installed it manually through ruff.vsix and launched the extension to verify continued functionality.

```console
python -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
npm install
npm run vsce-package
```