### PR TITLE
Update ruff README badge versions to 0.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Ruff extension for Visual Studio Code
 
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![image](https://img.shields.io/pypi/v/ruff/0.1.0.svg)](https://pypi.python.org/pypi/ruff)
-[![image](https://img.shields.io/pypi/l/ruff/0.1.0.svg)](https://pypi.python.org/pypi/ruff)
-[![image](https://img.shields.io/pypi/pyversions/ruff/0.1.0.svg)](https://pypi.python.org/pypi/ruff)
+[![image](https://img.shields.io/pypi/v/ruff/0.1.9.svg)](https://pypi.python.org/pypi/ruff)
+[![image](https://img.shields.io/pypi/l/ruff/0.1.9.svg)](https://pypi.python.org/pypi/ruff)
+[![image](https://img.shields.io/pypi/pyversions/ruff/0.1.9.svg)](https://pypi.python.org/pypi/ruff)
 [![Actions status](https://github.com/astral-sh/ruff-vscode/workflows/CI/badge.svg)](https://github.com/astral-sh/ruff-vscode/actions)
 
 A Visual Studio Code extension for [Ruff](https://github.com/astral-sh/ruff), an extremely fast


### PR DESCRIPTION
## Summary

Current ruff versions in README badges use `0.1.0`...

[![image](https://img.shields.io/pypi/v/ruff/0.1.0.svg)](https://pypi.python.org/pypi/ruff)
[![image](https://img.shields.io/pypi/l/ruff/0.1.0.svg)](https://pypi.python.org/pypi/ruff)
[![image](https://img.shields.io/pypi/pyversions/ruff/0.1.0.svg)](https://pypi.python.org/pypi/ruff)

...instead of `0.1.9`:

[![image](https://img.shields.io/pypi/v/ruff/0.1.9.svg)](https://pypi.python.org/pypi/ruff)
[![image](https://img.shields.io/pypi/l/ruff/0.1.9.svg)](https://pypi.python.org/pypi/ruff)
[![image](https://img.shields.io/pypi/pyversions/ruff/0.1.9.svg)](https://pypi.python.org/pypi/ruff)

Looks like missed in bump from `0.1.0` to `0.1.2` (#309).

## Test Plan

Updated the badges to `0.1.9` and then executed the script to bump the versions.

```console
./scripts/bump_ruff_version.sh 0.1.9 0.1.10
```

All versions - including those in the README badges - updated successfully.