### PR TITLE
Amend `notebook.source` actions on save recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Similarly, you can configure Ruff to organize imports on-save by enabling the
 {
   "[python]": {
     "editor.codeActionsOnSave": {
-      "notebook.source.organizeImports": true
+      "source.organizeImports": true
     }
   }
 }


### PR DESCRIPTION
Looks like this line got prefixed with `notebook` despite the setting targeting non-notebook files. Just a one-line change, so I hope it's alright I didn't raise an issue on it. Fixes what looks like a one-line error introduced in https://github.com/astral-sh/ruff-vscode/pull/379?