### PR TITLE
Include Alpine in target platforms

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,14 @@ jobs:
           - os: macos-latest-xlarge
             target: aarch64-apple-darwin
             code-target: darwin-arm64
+          - os: ubuntu-20.04
+            target: x86_64-unknown-linux-musl
+            code-target: alpine-x64
+            arch: x86_64
+          - os: ubuntu-20.04
+            target: aarch64-unknown-linux-musl
+            code-target: alpine-arm64
+            arch: aarch64
 
     name: Build (${{ matrix.target }})
     needs: ["build-id"]
@@ -95,7 +103,7 @@ jobs:
 
       # ARM builds on Ubuntu, which should select Ruff's ARM binary.
       - uses: uraimo/run-on-arch-action@v2
-        if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.target, 'x86_64') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.target, 'x86_64') && !endsWith(matrix.target, 'musl') }}
         with:
           arch: ${{ matrix.arch }}
           distro: ubuntu20.04
@@ -106,9 +114,22 @@ jobs:
           run: |
             python3 -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
 
+      # Alpine builds, which should select Ruff's musl binaries.
+      - uses: jirutka/setup-alpine@v1
+        if: ${{ startsWith(matrix.os, 'ubuntu') && endsWith(matrix.target, 'musl') }}
+        with:
+          arch: ${{ matrix.arch }}
+      - shell: alpine.sh --root {0}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && endsWith(matrix.target, 'musl') }}
+        run: |
+          apk add --no-cache python3 py3-pip
+          python3 -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
+
       # Every other architecture, which should defer to `pip` without any special treatment.
       - run: python -m pip install -t ./bundled/libs --implementation py --no-deps --upgrade -r ./requirements.txt
-        if: ${{ !startsWith(matrix.os, 'macos') && (!startsWith(matrix.os, 'ubuntu') || startsWith(matrix.target, 'x86_64')) }}
+        if: ${{ !startsWith(matrix.os, 'macos')
+                && !(startsWith(matrix.os, 'ubuntu') && !startsWith(matrix.target, 'x86_64') && !endsWith(matrix.target, 'musl'))
+                && !(startsWith(matrix.os, 'ubuntu') && endsWith(matrix.target, 'musl')) }}
 
       # Install Node.
       - name: Install Node.js
@@ -188,6 +209,14 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: dist-aarch64-pc-windows-msvc
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-unknown-linux-musl
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-aarch64-unknown-linux-musl
           path: dist
       - run: ls -al ./dist
 


### PR DESCRIPTION
## Summary

This PR ensures that we publish VS Code extensions for the `alpine-x86` and `alpine-arm64` target platforms.

See https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions for details:

> The currently available platforms are: win32-x64, win32-arm64, linux-x64, linux-arm64, linux-armhf, alpine-x64, alpine-arm64, darwin-x64, darwin-arm64 and web.

## Test Plan

Performed a dry run, and verified that Ruff selected the correct musl wheel for x86:

![Screenshot 2024-01-15 at 2 43 04 PM](https://github.com/astral-sh/ruff-vscode/assets/1309177/6ff5a1d1-0eda-4b05-ad3e-5a36a9aac821)

And again for arm:

![Screenshot 2024-01-15 at 2 42 56 PM](https://github.com/astral-sh/ruff-vscode/assets/1309177/9f42b62c-72af-4278-afbb-9326ae088335)
