### PR TITLE
Propagate build ID task error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Generate Build ID (release)
         if: "startsWith(github.ref, 'refs/tags/')"
         id: release-build-id-generator
+        shell: bash {0}
         run: |
           export BUILD_ID=$(python -m build.generate_build_id)
           echo "BUILD_ID: ${BUILD_ID}"
@@ -35,6 +36,7 @@ jobs:
       - name: Generate Build ID (nightly)
         if: "!startsWith(github.ref, 'refs/tags/')"
         id: nightly-build-id-generator
+        shell: bash {0}
         run: |
           export BUILD_ID=$(python -m build.generate_build_id --pre-release)
           echo "BUILD_ID: ${BUILD_ID}"


### PR DESCRIPTION
## Summary

See: https://github.com/astral-sh/ruff-vscode/actions/runs/7533695396/job/20506697608. If the commands fail, the step should fail.
