### PR TITLE
Allow opt-out of standard library detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This requires Ruff version `v0.1.3` or later.
 ## Settings
 
 | Settings                             | Default           | Description                                                                                                                                                                                                                                                       |
-| ------------------------------------ | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | lint.args                            | `[]`              | Additional command-line arguments to pass to `ruff check`, e.g., `"args": ["--config=/path/to/pyproject.toml"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`. |
 | path                                 | `[]`              | Path to a custom `ruff` executable, e.g., `["/path/to/ruff"]`.                                                                                                                                                                                                    |
 | interpreter                          | `[]`              | Path to a Python interpreter to use to run the linter server.                                                                                                                                                                                                     |
@@ -79,6 +79,7 @@ This requires Ruff version `v0.1.3` or later.
 | codeAction.fixViolation.enable       | `true`            | Whether to display Quick Fix actions to autofix violations.                                                                                                                                                                                                       |
 | codeAction.disableRuleComment.enable | `true`            | Whether to display Quick Fix actions to disable rules via `noqa` suppression comments.                                                                                                                                                                            |
 | showNotification                     | `off`             | Setting to control when a notification is shown: `off`, `onError`, `onWarning`, `always`.                                                                                                                                                                         |
+| ignoreStandardLibrary                | `true`            | Whether to ignore files that are inferred to be part of the Python standard library.                                                                                                                                                                              |
 
 ### Configuring VS Code
 

--- a/package.json
+++ b/package.json
@@ -203,6 +203,12 @@
           "additionalProperties": false,
           "markdownDescription": "Whether to display Quick Fix actions to disable rules via `noqa` suppression comments."
         },
+             "ruff.ignoreStandardLibrary": {
+          "default": true,
+          "markdownDescription": "Whether to ignore files that are inferred to be part of the Python standard library.",
+          "scope": "window",
+          "type": "boolean"
+        },
         "ruff.trace.server": {
           "type": "string",
           "enum": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.7"
 license = "MIT"
 dependencies = [
   "packaging>=23.1",
-  "ruff-lsp==0.0.49",
+  "ruff-lsp==0.0.50",
   "ruff==0.1.13",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -95,9 +95,9 @@ ruff==0.1.13 \
     # via
     #   ruff-lsp
     #   ruff-vscode (./pyproject.toml)
-ruff-lsp==0.0.49 \
-    --hash=sha256:28ce187fc50dfa16873b08d7df0038182a3d13a89a0f338e2dd77ecd624bb4db \
-    --hash=sha256:dc18046d7fdc81477435fe7b58407ba13964d2d1b67b8cd337d280f47dc405f0
+ruff-lsp==0.0.50 \
+    --hash=sha256:b0ae08a63084a37b4c0f85d4f144717ad5b454bc7d605014ab1b64fc5e52b9b2 \
+    --hash=sha256:e16b496c1ba82f29d7e9b9c24add835998f323795a746f507ea8f967346b916b
     # via ruff-vscode (./pyproject.toml)
 tomli==2.0.1 \
     --hash=sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc \

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,9 +59,9 @@ ruff==0.1.13 \
     # via
     #   ruff-lsp
     #   ruff-vscode (./pyproject.toml)
-ruff-lsp==0.0.49 \
-    --hash=sha256:28ce187fc50dfa16873b08d7df0038182a3d13a89a0f338e2dd77ecd624bb4db \
-    --hash=sha256:dc18046d7fdc81477435fe7b58407ba13964d2d1b67b8cd337d280f47dc405f0
+ruff-lsp==0.0.50 \
+    --hash=sha256:b0ae08a63084a37b4c0f85d4f144717ad5b454bc7d605014ab1b64fc5e52b9b2 \
+    --hash=sha256:e16b496c1ba82f29d7e9b9c24add835998f323795a746f507ea8f967346b916b
     # via ruff-vscode (./pyproject.toml)
 typing-extensions==4.7.1 \
     --hash=sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36 \

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -35,6 +35,7 @@ export interface ISettings {
   cwd: string;
   workspace: string;
   path: string[];
+  ignoreStandardLibrary: boolean;
   interpreter: string[];
   importStrategy: ImportStrategy;
   codeAction: CodeAction;
@@ -96,6 +97,7 @@ export async function getWorkspaceSettings(
     cwd: workspace.uri.fsPath,
     workspace: workspace.uri.toString(),
     path: resolveVariables(config.get<string[]>("path") ?? [], workspace),
+    ignoreStandardLibrary: config.get<boolean>("ignoreStandardLibrary") ?? true,
     interpreter: resolveVariables(interpreter, workspace),
     importStrategy: config.get<ImportStrategy>("importStrategy") ?? "fromEnvironment",
     codeAction: config.get<CodeAction>("codeAction") ?? {},
@@ -127,6 +129,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     cwd: process.cwd(),
     workspace: process.cwd(),
     path: getGlobalValue<string[]>(config, "path", []),
+    ignoreStandardLibrary: getGlobalValue<boolean>(config, "ignoreStandardLibrary", true),
     interpreter: [],
     importStrategy: getGlobalValue<ImportStrategy>(config, "importStrategy", "fromEnvironment"),
     codeAction: getGlobalValue<CodeAction>(config, "codeAction", {}),
@@ -152,6 +155,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.codeAction`,
     `${namespace}.enable`,
     `${namespace}.fixAll`,
+    `${namespace}.ignoreStandardLibrary`,
     `${namespace}.importStrategy`,
     `${namespace}.interpreter`,
     `${namespace}.lint.run`,


### PR DESCRIPTION
## Summary

Users can now specify `"ruff.ignoreStandardLIbrary": false` to turn off the standard library detection.

Closes https://github.com/astral-sh/ruff-vscode/issues/351.