### PR TITLE
Add Formatters to VS Code extension category

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "categories": [
     "Programming Languages",
-    "Linters"
+    "Linters",
+    "Formatters"
   ],
   "extensionDependencies": [
     "ms-python.python"


### PR DESCRIPTION
Reference: https://github.com/microsoft/vscode-black-formatter/blob/638976ed61283a1c2e17037182ca363683f2b3a3/package.json#L36