### PR TITLE
fix typo in README for the ruff.showNotifications setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This requires Ruff version `v0.1.3` or later.
 | lint.run                             | `onType`          | Run Ruff on every keystroke (`onType`) or on save (`onSave`).                                                                                                                                                                                                     |
 | organizeImports                      | `"explicit"`      | Whether to register Ruff as capable of handling `source.organizeImports` actions.                                                                                                                                                                                 |
 | path                                 | `[]`              | Path to a custom `ruff` executable, e.g., `["/path/to/ruff"]`.                                                                                                                                                                                                    |
-| showNotification                     | `off`             | Setting to control when a notification is shown: `off`, `onError`, `onWarning`, `always`.                                                                                                                                                                         |
+| showNotifications                    | `off`             | Setting to control when a notification is shown: `off`, `onError`, `onWarning`, `always`.                                                                                                                                                                         |
 
 ### Configuring VS Code
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

hi! fixed a simple typo in the root README. `showNotification` should be `showNotifications`. i double checked this in the source elsewhere. discovered the issue when adjusting the vscode setting myself, and reading the README.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

n/a

<!-- How was it tested? -->
