### PR TITLE
Remove warning about restarting VS Code that appeared when enabling/disabling the experimental server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,10 +66,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.window.showWarningMessage(
           "To enable or disable Ruff after changing the `enable` setting, you must restart VS Code.",
         );
-      } else if (event.affectsConfiguration("ruff.experimentalServer")) {
-        vscode.window.showWarningMessage(
-          "To enable or disable the experimental Ruff server, you must restart VS Code.",
-        );
       }
     }),
   );


### PR DESCRIPTION
## Summary

We don't actually need to tell the user to restart VS Code when changing this setting. I put this in as a precautionary measure but from the testing I've done there doesn't seem to be a need to restart it.

## Test Plan


https://github.com/astral-sh/ruff-vscode/assets/19577865/f1536261-abc7-4016-89c9-c61e9c4047a6


