### PR TITLE
refactor: remove unnecessary activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   "activationEvents": [
     "onLanguage:python",
     "workspaceContains:*.py",
-    "workspaceContains:*.ipynb",
-    "onCommand:ruff.restart"
+    "workspaceContains:*.ipynb"
   ],
   "main": "./dist/extension.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This change removes `"onCommand:ruff.restart"` from `"activationEvents"`, because VSCode generates it automatically from `package.json` contribution declarations.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
CI