### PR TITLE
Bump version to `2024.19.0-dev`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 See [here](https://github.com/charliermarsh/ruff/releases) for the Ruff release notes.
 
-## 2024.17.0
+## 2024.19.0-alpha
+
+This pre-release upgrades the bundled Ruff version to `v0.3.6`.
+
+The extension can now detect and use local `ruff` executables on your system, though it can still fall back to the bundled Ruff binary.
+
+The `v0.3.6` server introduces several major features:
+- Source actions like `source.fixAll` and `source.organizeImports` are now supported.
+- Extension commands are now supported.
+- Some extension settings now work as expected. See [the relevant PR](https://github.com/astral-sh/ruff/pull/10764) for more details.
+- Linter/formatter configuration is now reloaded automatically when you make changes to `ruff.toml` / `pyproject.toml` files.
+
+This release also brings significant quality-of-life improvements and fixes several bugs.
+
+## 2024.17.0-dev
 
 This pre-release introduces support for the new, experimental Ruff language server (`ruff server`). It also upgrades the bundled Ruff version to `v0.3.3`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See [here](https://github.com/charliermarsh/ruff/releases) for the Ruff release notes.
 
-## 2024.19.0-alpha
+## 2024.19.0-dev
 
 This pre-release upgrades the bundled Ruff version to `v0.3.6`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruff",
-  "version": "2024.19.0-alpha",
+  "version": "2024.19.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ruff",
-      "version": "2024.19.0-alpha",
+      "version": "2024.19.0-dev",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruff",
-  "version": "2024.17.0-dev",
+  "version": "2024.19.0-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ruff",
-      "version": "2024.17.0-dev",
+      "version": "2024.19.0-alpha",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ruff",
   "displayName": "Ruff",
   "description": "A Visual Studio Code extension with support for the Ruff linter.",
-  "version": "2024.19.0-alpha",
+  "version": "2024.19.0-dev",
   "serverInfo": {
     "name": "Ruff",
     "module": "ruff"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ruff",
   "displayName": "Ruff",
   "description": "A Visual Studio Code extension with support for the Ruff linter.",
-  "version": "2024.17.0-dev",
+  "version": "2024.19.0-alpha",
   "serverInfo": {
     "name": "Ruff",
     "module": "ruff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ruff-vscode"
-version = "2024.17.0-dev"
+version = "2024.19.0-alpha"
 description = "A Visual Studio Code extension with support for the Ruff linter."
 authors = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]
 maintainers = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ruff-vscode"
-version = "2024.19.0-alpha"
+version = "2024.19.0-dev"
 description = "A Visual Studio Code extension with support for the Ruff linter."
 authors = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]
 maintainers = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]


### PR DESCRIPTION
## Summary

Bumps the version to the first Alpha pre-release, `2024.19.0-dev`. A new changelog entry has also been added.