### PR TITLE
Introduce common Ruff configuration options to extension settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,34 +90,40 @@
           "type": "array"
         },
         "ruff.lint.preview": {
-          "markdownDescription": "Enable preview mode for the linter; enables unstable rules and fixes.",
-          "scope": "window",
-          "type": "boolean",
-          "default": null
+          "default": null,
+          "markdownDescription": "Enable [preview mode](https://docs.astral.sh/ruff/settings/#lint_preview) for the linter; enables unstable rules and fixes.",
+          "scope": "resource",
+          "type": "boolean"
         },
         "ruff.lint.select": {
-          "markdownDescription": "Set rule codes to enable. Use `ALL` to enable all rules.",
+          "default": null,
+          "markdownDescription": "Set rule codes to enable. Use `ALL` to enable all rules. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_select) for more details.",
+          "examples": [
+            ["E4", "E7", "E9", "F"]
+          ],
           "items": {
             "type": "string"
           },
-          "type": "array",
-          "default": null
+          "scope": "resource",
+          "type": "array"
         },
         "ruff.lint.extendSelect": {
+          "default": null,
           "markdownDescription": "Enable additional rule codes on top of existing configuration, instead of overriding it. Use `ALL` to enable all rules.",
           "items": {
             "type": "string"
           },
-          "type": "array",
-          "default": null
+          "scope": "resource",
+          "type": "array"
         },
         "ruff.lint.ignore": {
-          "markdownDescription": "Set rule codes to disable.",
+          "default": null,
+          "markdownDescription": "Set rule codes to disable. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_ignore) for more details.",
           "items": {
             "type": "string"
           },
-          "type": "array",
-          "default": null
+          "scope": "resource",
+          "type": "array"
         },
         "ruff.run": {
           "default": "onType",
@@ -165,10 +171,10 @@
           "type": "array"
         },
         "ruff.format.preview": {
-          "markdownDescription": "Enable preview mode for the formatter; enables unstable formatting.",
-          "scope": "window",
-          "type": "boolean",
-          "default": null
+          "default": null,
+          "markdownDescription": "Enable [preview mode](https://docs.astral.sh/ruff/settings/#format_preview) for the formatter; enables unstable formatting.",
+          "scope": "resource",
+          "type": "boolean"
         },
         "ruff.path": {
           "default": [],
@@ -287,19 +293,21 @@
           "type": "string"
         },
         "ruff.exclude": {
-          "markdownDescription": "Set paths for the linter and formatter to ignore.",
-          "scope": "window",
+          "default": null,
           "items": {
             "type": "string"
           },
+          "markdownDescription": "Set paths for the linter and formatter to ignore. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_exclude) for more details.",
           "type": "array",
-          "default": null
+          "scope": "resource"
         },
         "ruff.lineLength": {
-          "markdownDescription": "Set the line length used by the formatter and linter.",
-          "scope": "window",
-          "type": ["integer", "null"],
-          "default": null
+          "default": null,
+          "minimum": 1,
+          "maximum": 320,
+          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0 and less than or equal to 320.",
+          "scope": "resource",
+          "type": ["integer", "null"]
         },
         "ruff.enableExperimentalFormatter": {
           "default": false,

--- a/package.json
+++ b/package.json
@@ -89,6 +89,36 @@
           "scope": "resource",
           "type": "array"
         },
+        "ruff.lint.preview": {
+          "markdownDescription": "Enable preview mode for the linter; enables unstable rules and fixes.",
+          "scope": "window",
+          "type": "boolean",
+          "default": null
+        },
+        "ruff.lint.select": {
+          "markdownDescription": "Set rule codes to enable. Use `ALL` to enable all rules.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "default": null
+        },
+        "ruff.lint.extendSelect": {
+          "markdownDescription": "Enable additional rule codes on top of existing configuration, instead of overriding it. Use `ALL` to enable all rules.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "default": null
+        },
+        "ruff.lint.ignore": {
+          "markdownDescription": "Set rule codes to disable.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "default": null
+        },
         "ruff.run": {
           "default": "onType",
           "markdownDescription": "Run Ruff on every keystroke (`onType`) or on save (`onSave`).",
@@ -133,6 +163,12 @@
           },
           "scope": "resource",
           "type": "array"
+        },
+        "ruff.format.preview": {
+          "markdownDescription": "Enable preview mode for the formatter; enables unstable formatting.",
+          "scope": "window",
+          "type": "boolean",
+          "default": null
         },
         "ruff.path": {
           "default": [],
@@ -249,6 +285,21 @@
           ],
           "scope": "window",
           "type": "string"
+        },
+        "ruff.exclude": {
+          "markdownDescription": "Set paths for the linter and formatter to ignore.",
+          "scope": "window",
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "default": null
+        },
+        "ruff.lineLength": {
+          "markdownDescription": "Set the line length used by the formatter and linter.",
+          "scope": "window",
+          "type": ["integer", "null"],
+          "default": null
         },
         "ruff.enableExperimentalFormatter": {
           "default": false,

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -91,14 +91,6 @@ export function getInterpreterFromSetting(namespace: string, scope?: Configurati
   return config.get<string[]>("interpreter");
 }
 
-function getLineLength(configuration: WorkspaceConfiguration, key: string): number | undefined {
-  let lineLength = configuration.get<number>(key);
-  if (lineLength && lineLength > 0 && lineLength <= 320) {
-    return lineLength;
-  }
-  return undefined;
-}
-
 export async function getWorkspaceSettings(
   namespace: string,
   workspace: WorkspaceFolder,
@@ -140,7 +132,7 @@ export async function getWorkspaceSettings(
     fixAll: config.get<boolean>("fixAll") ?? true,
     showNotifications: config.get<string>("showNotifications") ?? "off",
     exclude: config.get<string[]>("exclude"),
-    lineLength: getLineLength(config, "lineLength"),
+    lineLength: config.get<number>("lineLength"),
   };
 }
 
@@ -152,14 +144,6 @@ function getGlobalValue<T>(config: WorkspaceConfiguration, key: string, defaultV
 function getOptionalGlobalValue<T>(config: WorkspaceConfiguration, key: string): T | undefined {
   const inspect = config.inspect<T>(key);
   return inspect?.globalValue;
-}
-
-function getGlobalLineLength(config: WorkspaceConfiguration, key: string): number | undefined {
-  let lineLength = config.inspect<number>(key)?.globalValue;
-  if (lineLength && lineLength > 0 && lineLength <= 320) {
-    return lineLength;
-  }
-  return undefined;
 }
 
 export async function getGlobalSettings(namespace: string): Promise<ISettings> {
@@ -191,7 +175,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     fixAll: getGlobalValue<boolean>(config, "fixAll", true),
     showNotifications: getGlobalValue<string>(config, "showNotifications", "off"),
     exclude: getOptionalGlobalValue<string[]>(config, "exclude"),
-    lineLength: getGlobalLineLength(config, "lineLength"),
+    lineLength: getOptionalGlobalValue<number>(config, "lineLength"),
   };
 }
 

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -26,10 +26,15 @@ type Lint = {
   enable?: boolean;
   args?: string[];
   run?: Run;
+  preview?: boolean;
+  select?: string[];
+  extendSelect?: string[];
+  ignore?: string[];
 };
 
 type Format = {
   args?: string[];
+  preview?: boolean;
 };
 
 export interface ISettings {
@@ -47,6 +52,8 @@ export interface ISettings {
   fixAll: boolean;
   lint: Lint;
   format: Format;
+  exclude?: string[];
+  lineLength?: number;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -84,6 +91,14 @@ export function getInterpreterFromSetting(namespace: string, scope?: Configurati
   return config.get<string[]>("interpreter");
 }
 
+function getLineLength(configuration: WorkspaceConfiguration, key: string): number | undefined {
+  let lineLength = configuration.get<number>(key);
+  if (lineLength && lineLength > 0 && lineLength <= 320) {
+    return lineLength;
+  }
+  return undefined;
+}
+
 export async function getWorkspaceSettings(
   namespace: string,
   workspace: WorkspaceFolder,
@@ -111,20 +126,40 @@ export async function getWorkspaceSettings(
         getPreferredWorkspaceSetting<string[]>("lint.args", "args", config) ?? [],
         workspace,
       ),
+      preview: config.get<boolean>("lint.preview"),
+      select: config.get<string[]>("lint.select"),
+      extendSelect: config.get<string[]>("lint.extendSelect"),
+      ignore: config.get<string[]>("lint.ignore"),
     },
     format: {
       args: resolveVariables(config.get<string[]>("format.args") ?? [], workspace),
+      preview: config.get<boolean>("format.preview"),
     },
     enable: config.get<boolean>("enable") ?? true,
     organizeImports: config.get<boolean>("organizeImports") ?? true,
     fixAll: config.get<boolean>("fixAll") ?? true,
     showNotifications: config.get<string>("showNotifications") ?? "off",
+    exclude: config.get<string[]>("exclude"),
+    lineLength: getLineLength(config, "lineLength"),
   };
 }
 
 function getGlobalValue<T>(config: WorkspaceConfiguration, key: string, defaultValue: T): T {
   const inspect = config.inspect<T>(key);
   return inspect?.globalValue ?? inspect?.defaultValue ?? defaultValue;
+}
+
+function getOptionalGlobalValue<T>(config: WorkspaceConfiguration, key: string): T | undefined {
+  const inspect = config.inspect<T>(key);
+  return inspect?.globalValue;
+}
+
+function getGlobalLineLength(config: WorkspaceConfiguration, key: string): number | undefined {
+  let lineLength = config.inspect<number>(key)?.globalValue;
+  if (lineLength && lineLength > 0 && lineLength <= 320) {
+    return lineLength;
+  }
+  return undefined;
 }
 
 export async function getGlobalSettings(namespace: string): Promise<ISettings> {
@@ -142,14 +177,21 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
       enable: getPreferredGlobalSetting<boolean>("lint.enable", "enable", config) ?? true,
       run: getPreferredGlobalSetting<Run>("lint.run", "run", config) ?? "onType",
       args: getPreferredGlobalSetting<string[]>("lint.args", "args", config) ?? [],
+      preview: getOptionalGlobalValue<boolean>(config, "lint.preview"),
+      select: getOptionalGlobalValue<string[]>(config, "lint.select"),
+      extendSelect: getOptionalGlobalValue<string[]>(config, "lint.extendSelect"),
+      ignore: getOptionalGlobalValue<string[]>(config, "lint.ignore"),
     },
     format: {
       args: getGlobalValue<string[]>(config, "format.args", []),
+      preview: getOptionalGlobalValue<boolean>(config, "format.preview"),
     },
     enable: getGlobalValue<boolean>(config, "enable", true),
     organizeImports: getGlobalValue<boolean>(config, "organizeImports", true),
     fixAll: getGlobalValue<boolean>(config, "fixAll", true),
     showNotifications: getGlobalValue<string>(config, "showNotifications", "off"),
+    exclude: getOptionalGlobalValue<string[]>(config, "exclude"),
+    lineLength: getGlobalLineLength(config, "lineLength"),
   };
 }
 
@@ -167,9 +209,16 @@ export function checkIfConfigurationChanged(
     `${namespace}.interpreter`,
     `${namespace}.lint.enable`,
     `${namespace}.lint.run`,
+    `${namespace}.lint.preview`,
+    `${namespace}.lint.select`,
+    `${namespace}.lint.extendSelect`,
+    `${namespace}.lint.ignore`,
     `${namespace}.organizeImports`,
     `${namespace}.path`,
     `${namespace}.showNotifications`,
+    `${namespace}.format.preview`,
+    `${namespace}.exclude`,
+    `${namespace}.lineLength`,
     // Deprecated settings (prefer `lint.args`, etc.).
     `${namespace}.args`,
     `${namespace}.run`,


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/astral-sh/ruff/pull/10984, which implemented support for common Ruff configuration options in client settings. This PR exposes these new settings in the extension configuration.

These settings are different from other extension settings, because they don't have default values. Instead, if the user does not set them, they will be sent as `null`, and the server will use project configuration instead.

At the moment, `ruff server` does not actually resolve these settings yet - settings resolution is introduced in https://github.com/astral-sh/ruff/pull/11062, which means that you'll need to work from that branch to test this PR (and vice-versa).

## Test Plan

See the test plan in https://github.com/astral-sh/ruff/pull/11062.