### PR TITLE
Support prioritizing discovered TOML settings over editor settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,6 +309,12 @@
           "scope": "resource",
           "type": ["integer", "null"]
         },
+        "ruff.prioritizeFileConfiguration": {
+          "markdownDescription": "Whether to prioritize file configuration over configuration set in extension settings.",
+          "scope": "window",
+          "type": "boolean",
+          "default": false
+        },
         "ruff.enableExperimentalFormatter": {
           "default": false,
           "markdownDescription": "Controls whether Ruff registers as capable of code formatting.",

--- a/package.json
+++ b/package.json
@@ -309,11 +309,19 @@
           "scope": "resource",
           "type": ["integer", "null"]
         },
-        "ruff.prioritizeFileConfiguration": {
-          "markdownDescription": "Whether to prioritize file configuration over configuration set in extension settings.",
-          "scope": "window",
-          "type": "boolean",
-          "default": false
+        "ruff.configurationResolutionStrategy": {
+          "enum": [
+            "default",
+            "prioritizeWorkspace"
+          ],
+          "enumDescriptions": [
+            "The default strategy - configuration set in the editor takes priority over configuration set in `.toml` files.",
+            "An alternative strategy - configuration set in `.toml` files takes priority over configuration set in the editor."
+          ],
+          "markdownDescription": "The resolution strategy used to merge configuration set in the editor with configuration set in local `.toml` files.",
+          "scope": "resource",
+          "type": "string",
+          "default": "default"
         },
         "ruff.enableExperimentalFormatter": {
           "default": false,

--- a/package.json
+++ b/package.json
@@ -309,19 +309,21 @@
           "scope": "resource",
           "type": ["integer", "null"]
         },
-        "ruff.configurationResolutionStrategy": {
+        "ruff.configurationPreference": {
           "enum": [
-            "default",
-            "prioritizeWorkspace"
+            "editorFirst",
+            "filesystemFirst",
+            "editorOnly"
           ],
           "enumDescriptions": [
             "The default strategy - configuration set in the editor takes priority over configuration set in `.toml` files.",
-            "An alternative strategy - configuration set in `.toml` files takes priority over configuration set in the editor."
+            "An alternative strategy - configuration set in `.toml` files takes priority over configuration set in the editor.",
+            "An alternative strategy - configuration set in `.toml` files is ignored entirely."
           ],
-          "markdownDescription": "The resolution strategy used to merge configuration set in the editor with configuration set in local `.toml` files.",
+          "markdownDescription": "The preferred method of resolving configuration in the editor with local configuration froml `.toml` files.",
           "scope": "resource",
           "type": "string",
-          "default": "default"
+          "default": "editorFirst"
         },
         "ruff.enableExperimentalFormatter": {
           "default": false,

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -13,6 +13,8 @@ type ImportStrategy = "fromEnvironment" | "useBundled";
 
 type Run = "onType" | "onSave";
 
+type ConfigResolutionStrategy = "default" | "prioritizeWorkspace";
+
 type CodeAction = {
   disableRuleComment?: {
     enable?: boolean;
@@ -54,7 +56,7 @@ export interface ISettings {
   format: Format;
   exclude?: string[];
   lineLength?: number;
-  prioritizeFileConfiguration?: boolean;
+  configurationResolutionStrategy?: ConfigResolutionStrategy;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -142,7 +144,8 @@ export async function getWorkspaceSettings(
     showNotifications: config.get<string>("showNotifications") ?? "off",
     exclude: config.get<string[]>("exclude"),
     lineLength: config.get<number>("lineLength"),
-    prioritizeFileConfiguration: config.get<boolean>("prioritizeFileConfiguration") ?? false,
+    configurationResolutionStrategy:
+      config.get<ConfigResolutionStrategy>("configurationResolutionStrategy") ?? "default",
   };
 }
 
@@ -186,10 +189,10 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     showNotifications: getGlobalValue<string>(config, "showNotifications", "off"),
     exclude: getOptionalGlobalValue<string[]>(config, "exclude"),
     lineLength: getOptionalGlobalValue<number>(config, "lineLength"),
-    prioritizeFileConfiguration: getGlobalValue<boolean>(
+    configurationResolutionStrategy: getGlobalValue<ConfigResolutionStrategy>(
       config,
-      "prioritizeFileConfiguration",
-      false,
+      "configurationResolutionStrategy",
+      "default",
     ),
   };
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -91,6 +91,14 @@ export function getInterpreterFromSetting(namespace: string, scope?: Configurati
   return config.get<string[]>("interpreter");
 }
 
+function getLineLength(configuration: WorkspaceConfiguration, key: string): number | undefined {
+  let lineLength = configuration.get<number>(key);
+  if (lineLength && lineLength > 0 && lineLength <= 320) {
+    return lineLength;
+  }
+  return undefined;
+}
+
 export async function getWorkspaceSettings(
   namespace: string,
   workspace: WorkspaceFolder,

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -13,7 +13,7 @@ type ImportStrategy = "fromEnvironment" | "useBundled";
 
 type Run = "onType" | "onSave";
 
-type ConfigResolutionStrategy = "default" | "prioritizeWorkspace";
+type ConfigPreference = "editorFirst" | "filesystemFirst" | "editorOnly";
 
 type CodeAction = {
   disableRuleComment?: {
@@ -56,7 +56,7 @@ export interface ISettings {
   format: Format;
   exclude?: string[];
   lineLength?: number;
-  configurationResolutionStrategy?: ConfigResolutionStrategy;
+  configurationPreference?: ConfigPreference;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -92,14 +92,6 @@ function resolveVariables(value: string[], workspace?: WorkspaceFolder): string[
 export function getInterpreterFromSetting(namespace: string, scope?: ConfigurationScope) {
   const config = getConfiguration(namespace, scope);
   return config.get<string[]>("interpreter");
-}
-
-function getLineLength(configuration: WorkspaceConfiguration, key: string): number | undefined {
-  let lineLength = configuration.get<number>(key);
-  if (lineLength && lineLength > 0 && lineLength <= 320) {
-    return lineLength;
-  }
-  return undefined;
 }
 
 export async function getWorkspaceSettings(
@@ -144,8 +136,8 @@ export async function getWorkspaceSettings(
     showNotifications: config.get<string>("showNotifications") ?? "off",
     exclude: config.get<string[]>("exclude"),
     lineLength: config.get<number>("lineLength"),
-    configurationResolutionStrategy:
-      config.get<ConfigResolutionStrategy>("configurationResolutionStrategy") ?? "default",
+    configurationPreference:
+      config.get<ConfigPreference>("configurationPreference") ?? "editorFirst",
   };
 }
 
@@ -189,10 +181,10 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     showNotifications: getGlobalValue<string>(config, "showNotifications", "off"),
     exclude: getOptionalGlobalValue<string[]>(config, "exclude"),
     lineLength: getOptionalGlobalValue<number>(config, "lineLength"),
-    configurationResolutionStrategy: getGlobalValue<ConfigResolutionStrategy>(
+    configurationPreference: getGlobalValue<ConfigPreference>(
       config,
-      "configurationResolutionStrategy",
-      "default",
+      "configurationPreference",
+      "editorFirst",
     ),
   };
 }
@@ -221,7 +213,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.format.preview`,
     `${namespace}.exclude`,
     `${namespace}.lineLength`,
-    `${namespace}.prioritizeFileConfiguration`,
+    `${namespace}.configurationPreference`,
     // Deprecated settings (prefer `lint.args`, etc.).
     `${namespace}.args`,
     `${namespace}.run`,

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -54,6 +54,7 @@ export interface ISettings {
   format: Format;
   exclude?: string[];
   lineLength?: number;
+  prioritizeFileConfiguration?: boolean;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -141,6 +142,7 @@ export async function getWorkspaceSettings(
     showNotifications: config.get<string>("showNotifications") ?? "off",
     exclude: config.get<string[]>("exclude"),
     lineLength: config.get<number>("lineLength"),
+    prioritizeFileConfiguration: config.get<boolean>("prioritizeFileConfiguration") ?? false,
   };
 }
 
@@ -184,6 +186,11 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     showNotifications: getGlobalValue<string>(config, "showNotifications", "off"),
     exclude: getOptionalGlobalValue<string[]>(config, "exclude"),
     lineLength: getOptionalGlobalValue<number>(config, "lineLength"),
+    prioritizeFileConfiguration: getGlobalValue<boolean>(
+      config,
+      "prioritizeFileConfiguration",
+      false,
+    ),
   };
 }
 
@@ -211,6 +218,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.format.preview`,
     `${namespace}.exclude`,
     `${namespace}.lineLength`,
+    `${namespace}.prioritizeFileConfiguration`,
     // Deprecated settings (prefer `lint.args`, etc.).
     `${namespace}.args`,
     `${namespace}.run`,


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff-vscode/issues/425 (though only in the pre-release version, since this is a feature for the new LSP server)

This is a follow-up to https://github.com/astral-sh/ruff-vscode/pull/456.

A new setting has been introduced, `Prioritize File Configuration`, which tells the extension to prioritize settings from discovered TOML files over extension settings. Extension settings will still be used when a set field in the extension is not set in the file configuration.

## Test Plan

Refer to https://github.com/astral-sh/ruff/pull/11086 for a test plan.