### PR TITLE
Expose configuration file argument for experimental server

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,12 @@
           "scope": "window",
           "type": "boolean"
         },
+        "ruff.configuration": {
+          "default": null,
+          "markdownDescription": "**Warning**: This setting is only respected when the experimental Ruff language server is enabled. Path to a `ruff.toml` or `pyproject.toml` file to use for configuration. By default, Ruff will discover configuration for each project from the filesystem, mirroring the behavior of the Ruff CLI.",
+          "scope": "window",
+          "type": "string"
+        },
         "ruff.args": {
           "default": [],
           "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -1,11 +1,9 @@
 import {
   ConfigurationChangeEvent,
   ConfigurationScope,
-  Uri,
   WorkspaceConfiguration,
   WorkspaceFolder,
 } from "vscode";
-import { traceError } from "./log/logging";
 import { getInterpreterDetails } from "./python";
 import { getConfiguration, getWorkspaceFolders } from "./vscodeapi";
 
@@ -39,6 +37,7 @@ export interface ISettings {
   path: string[];
   ignoreStandardLibrary: boolean;
   interpreter: string[];
+  configuration: string | null;
   importStrategy: ImportStrategy;
   codeAction: CodeAction;
   enable: boolean;
@@ -102,6 +101,7 @@ export async function getWorkspaceSettings(
     path: resolveVariables(config.get<string[]>("path") ?? [], workspace),
     ignoreStandardLibrary: config.get<boolean>("ignoreStandardLibrary") ?? true,
     interpreter: resolveVariables(interpreter, workspace),
+    configuration: config.get<string | null>("configuration") ?? null,
     importStrategy: config.get<ImportStrategy>("importStrategy") ?? "fromEnvironment",
     codeAction: config.get<CodeAction>("codeAction") ?? {},
     lint: {
@@ -136,6 +136,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     path: getGlobalValue<string[]>(config, "path", []),
     ignoreStandardLibrary: getGlobalValue<boolean>(config, "ignoreStandardLibrary", true),
     interpreter: [],
+    configuration: getGlobalValue<string | null>(config, "configuration", null),
     importStrategy: getGlobalValue<ImportStrategy>(config, "importStrategy", "fromEnvironment"),
     codeAction: getGlobalValue<CodeAction>(config, "codeAction", {}),
     lint: {
@@ -159,6 +160,7 @@ export function checkIfConfigurationChanged(
 ): boolean {
   const settings = [
     `${namespace}.codeAction`,
+    `${namespace}.configuration`,
     `${namespace}.enable`,
     `${namespace}.experimentalServer`,
     `${namespace}.fixAll`,


### PR DESCRIPTION
## Summary

The new LSP supports a configuration file, and I wanted to debug some issues with it, but found that it wasn't yet wired up to VS Code.

## Test Plan

Added a configuration file; verified in the logging that the LSP attempted to read it.

![Screenshot 2024-05-04 at 1 14 46 PM](https://github.com/astral-sh/ruff-vscode/assets/1309177/8eea4a5f-a03a-4ab3-877b-f080a21aca39)
