### PR TITLE
Enable fix/formatting commands for Python and Jupyter Notebook files only

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,7 +370,23 @@
         "category": "Ruff",
         "command": "ruff.restart"
       }
-    ]
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "ruff.executeAutofix",
+          "when": "resourceExtname == .py || resourceExtname == .pyi || resourceExtname == .ipynb"
+        },
+        {
+          "command": "ruff.executeFormat",
+          "when": "resourceExtname == .py || resourceExtname == .pyi || resourceExtname == .ipynb"
+        },
+        {
+          "command": "ruff.executeOrganizeImports",
+          "when": "resourceExtname == .py || resourceExtname == .pyi || resourceExtname == .ipynb"
+        }
+      ]
+    }
   },
   "dependencies": {
     "fs-extra": "^11.1.1",


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff/issues/11744.

The extension would allow commands like `ruff.applyAutofix` to run on any file, even non-Python files. This PR adds a command palette filter so that these commands only appear in the palette when working with Python or Jupyter Notebook files.

## Test Plan

Ensure that commands like `Ruff: Fix all auto-fixable problems` still appear in the command palette (`Ctrl/Cmd + Shift + P`) for files with the following extensions:
* `*.py`
* `*.pyi`
* `*.ipynb`

Then, ensure that these commands do not appear for other kinds of files (for example: `*.toml` or `*.json`). `Ruff: Restart server` should still be available.
