### PR TITLE
Remove the server trace level override that was based on the extension log level

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -24,7 +24,7 @@ import {
   ISettings,
 } from "./settings";
 import { updateStatus } from "./status";
-import { getLSClientTraceLevel, getProjectRoot } from "./utilities";
+import { getProjectRoot } from "./utilities";
 import { isVirtualWorkspace } from "./vscodeapi";
 
 export type IInitOptions = {
@@ -201,7 +201,5 @@ export async function restartServer(
     return undefined;
   }
 
-  const level = getLSClientTraceLevel(outputChannel.logLevel, env.logLevel);
-  await newLSClient.setTrace(level);
   return newLSClient;
 }

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -22,19 +22,6 @@ function logLevelToTrace(logLevel: LogLevel): Trace {
   }
 }
 
-export function getLSClientTraceLevel(channelLogLevel: LogLevel, globalLogLevel: LogLevel): Trace {
-  if (channelLogLevel === LogLevel.Off) {
-    return logLevelToTrace(globalLogLevel);
-  }
-  if (globalLogLevel === LogLevel.Off) {
-    return logLevelToTrace(channelLogLevel);
-  }
-  const level = logLevelToTrace(
-    channelLogLevel <= globalLogLevel ? channelLogLevel : globalLogLevel,
-  );
-  return level;
-}
-
 export async function getProjectRoot(): Promise<WorkspaceFolder> {
   const workspaces: readonly WorkspaceFolder[] = getWorkspaceFolders();
   if (workspaces.length === 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,6 @@ import {
 } from "./common/settings";
 import { loadServerDefaults } from "./common/setup";
 import { registerLanguageStatusItem, updateStatus } from "./common/status";
-import { getLSClientTraceLevel } from "./common/utilities";
 import {
   createOutputChannel,
   getConfiguration,
@@ -40,20 +39,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Setup logging
   const outputChannel = createOutputChannel(serverName);
   context.subscriptions.push(outputChannel, registerLogger(outputChannel));
-
-  const changeLogLevel = async (c: vscode.LogLevel, g: vscode.LogLevel) => {
-    const level = getLSClientTraceLevel(c, g);
-    await lsClient?.setTrace(level);
-  };
-
-  context.subscriptions.push(
-    outputChannel.onDidChangeLogLevel(async (e) => {
-      await changeLogLevel(e, vscode.env.logLevel);
-    }),
-    vscode.env.onDidChangeLogLevel(async (e) => {
-      await changeLogLevel(outputChannel.logLevel, e);
-    }),
-  );
 
   // Log Server information
   traceLog(`Name: ${serverInfo.name}`);


### PR DESCRIPTION
## Summary

Fixes #488.

We no longer override the trace level on server restarts. This means that the trace level will always be set to the value of `ruff.trace.server`.

## Test Plan

With `ruff.trace.server` set to `"off"`, you should no longer see logs in the output marked as `[Trace - ...]`.

Before:
<img width="1054" alt="Screenshot 2024-06-05 at 11 05 41 AM" src="https://github.com/astral-sh/ruff-vscode/assets/19577865/15832b31-1e58-468d-8210-e2ebcc632875">

After:
<img width="1055" alt="Screenshot 2024-06-05 at 11 06 56 AM" src="https://github.com/astral-sh/ruff-vscode/assets/19577865/93d7b04a-4375-49ab-9f12-1ae980f8a6e8">