### PR TITLE
Introduce `ruff.printDebugInformation` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,9 +366,9 @@
         "command": "ruff.executeOrganizeImports"
       },
       {
-        "title": "Print debug information",
+        "title": "Print debug information (native server only)",
         "category": "Ruff",
-        "command": "ruff.printDebugInformation"
+        "command": "ruff.debugInformation"
       },
       {
         "title": "Restart Server",

--- a/package.json
+++ b/package.json
@@ -366,6 +366,11 @@
         "command": "ruff.executeOrganizeImports"
       },
       {
+        "title": "Print debug information",
+        "category": "Ruff",
+        "command": "ruff.printDebugInformation"
+      },
+      {
         "title": "Restart Server",
         "category": "Ruff",
         "command": "ruff.restart"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -191,6 +191,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       });
     }),
     registerCommand(`${serverId}.executeFormat`, async () => {
+      // let configuration = getConfiguration(serverId) as ISettings;
+
       if (!lsClient) {
         return;
       }
@@ -240,8 +242,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         );
       });
     }),
-    registerCommand(`${serverId}.printDebugInformation`, async () => {
-      if (!lsClient) {
+    registerCommand(`${serverId}.debugInformation`, async () => {
+      let configuration = getConfiguration(serverId) as unknown as ISettings;
+      if (!lsClient || !configuration.nativeServer) {
         return;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -240,6 +240,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         );
       });
     }),
+    registerCommand(`${serverId}.printDebugInformation`, async () => {
+      if (!lsClient) {
+        return;
+      }
+
+      const params = {
+        command: `${serverId}.printDebugInformation`,
+      };
+
+      await lsClient.sendRequest(ExecuteCommandRequest.type, params).then(undefined, async () => {
+        await vscode.window.showErrorMessage("Failed to print debug information.");
+      });
+    }),
     registerLanguageStatusItem(serverId, serverName, `${serverId}.showLogs`),
   );
 


### PR DESCRIPTION
## Summary

Introduces a command to print debug information. It should look like this in the Output window:

<img width="632" alt="Screenshot 2024-06-10 at 12 21 07 PM" src="https://github.com/astral-sh/ruff-vscode/assets/19577865/671c38a0-00f6-4fd1-a4e6-824cc788b54f">

## Test Plan

See https://github.com/astral-sh/ruff/pull/11831 for testing information.
