### PR TITLE
Add `showSyntaxErrors` extension setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ This requires Ruff version `v0.1.3` or later.
 | `organizeImports`                      | `"explicit"`      | Whether to register Ruff as capable of handling `source.organizeImports` actions.                                                                                                           |
 | `path`                                 | `[]`              | Path to a custom `ruff` executable, e.g., `["/path/to/ruff"]`.                                                                                                                              |
 | `showNotifications`                    | `off`             | Setting to control when a notification is shown: `off`, `onError`, `onWarning`, `always`.                                                                                                   |
-| `nativeServer`                         | `false`           | Whether to use the Rust-based language server.                                                                                                                                              |
 | `showSyntaxErrors`                     | `true`            | Whether to show syntax error diagnostics. _New in Ruff v0.5.0_                                                                                                                              |
+| `nativeServer`                         | `false`           | Whether to use the Rust-based language server.                                                                                                                                              |
 
 The following settings are exclusive to the Rust-based language server (`nativeServer: true`), and
 are available in addition to those listed above:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This requires Ruff version `v0.1.3` or later.
 | `path`                                 | `[]`              | Path to a custom `ruff` executable, e.g., `["/path/to/ruff"]`.                                                                                                                              |
 | `showNotifications`                    | `off`             | Setting to control when a notification is shown: `off`, `onError`, `onWarning`, `always`.                                                                                                   |
 | `nativeServer`                         | `false`           | Whether to use the Rust-based language server.                                                                                                                                              |
+| `showSyntaxErrors`                     | `true`            | Whether to show syntax error diagnostics. _New in Ruff v0.5.0_                                                                                                                              |
 
 The following settings are exclusive to the Rust-based language server (`nativeServer: true`), and
 are available in addition to those listed above:

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
         },
         "ruff.showSyntaxErrors": {
           "default": true,
-          "markdownDescription": "Controls whether Ruff should show syntax error diagnostics.",
+          "markdownDescription": "Whether to show syntax error diagnostics.",
           "scope": "window",
           "type": "boolean"
         },

--- a/package.json
+++ b/package.json
@@ -269,6 +269,12 @@
           "additionalProperties": false,
           "markdownDescription": "Whether to display Quick Fix actions to disable rules via `noqa` suppression comments."
         },
+        "ruff.showSyntaxErrors": {
+          "default": true,
+          "markdownDescription": "Controls whether Ruff should show syntax error diagnostics.",
+          "scope": "window",
+          "type": "boolean"
+        },
         "ruff.ignoreStandardLibrary": {
           "default": true,
           "markdownDescription": "Whether to ignore files that are inferred to be part of the Python standard library.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -56,6 +56,7 @@ export interface ISettings {
   exclude?: string[];
   lineLength?: number;
   configurationPreference?: ConfigPreference;
+  showSyntaxErrors: boolean;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -156,6 +157,7 @@ export async function getWorkspaceSettings(
     lineLength: config.get<number>("lineLength"),
     configurationPreference:
       config.get<ConfigPreference>("configurationPreference") ?? "editorFirst",
+    showSyntaxErrors: config.get<boolean>("showSyntaxErrors") ?? true,
   };
 }
 
@@ -205,6 +207,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
       "configurationPreference",
       "editorFirst",
     ),
+    showSyntaxErrors: getGlobalValue<boolean>(config, "showSyntaxErrors", true),
   };
 }
 
@@ -234,6 +237,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.exclude`,
     `${namespace}.lineLength`,
     `${namespace}.configurationPreference`,
+    `${namespace}.showSyntaxErrors`,
     // Deprecated settings (prefer `lint.args`, etc.).
     `${namespace}.args`,
     `${namespace}.run`,


### PR DESCRIPTION
## Summary

This PR adds a `ruff.showSyntaxErrors` config option for https://github.com/astral-sh/ruff/pull/12059.

## Test Plan

Refer to the test plan in https://github.com/astral-sh/ruff/pull/12059.