### PR TITLE
Support automatic `ruff server` enablement

### DIFF
--- a/bundled/tool/ruff_server.py
+++ b/bundled/tool/ruff_server.py
@@ -44,17 +44,6 @@ def executable_version(executable: str) -> Version:
     return Version(version)
 
 
-def check_compatibility(
-    executable: str,
-    requirement: SpecifierSet,
-) -> None:
-    """Check the executable for compatibility against various version specifiers."""
-    version = executable_version(executable)
-    if not requirement.contains(version, prereleases=True):
-        message = f"Ruff {requirement} required, but found {version} at {executable}"
-        raise RuntimeError(message)
-
-
 def find_ruff_bin(fallback: Path) -> Path:
     """Return the ruff binary path."""
     bin_path = Path(sysconfig.get_path("scripts")) / RUFF_EXE
@@ -87,6 +76,5 @@ if __name__ == "__main__":
             Path(BUNDLE_DIR / "libs" / "bin" / RUFF_EXE),
         ),
     )
-    check_compatibility(ruff, RUFF_VERSION_REQUIREMENT)
     completed_process = subprocess.run([ruff, *sys.argv[1:]], check=False)
     sys.exit(completed_process.returncode)

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
       "properties": {
         "ruff.languageServer": {
           "type": "string",
-          "markdownDescription": "Set the language server for the extension to use. By default (in `automatic mode`), the extension will use the native server if the active Ruff version is `v0.4.5` or greater, and will use `ruff-lsp` otherwise. `native` will force the extension to always use `ruff server`, and legacy will force the extension to always use `ruff-lsp`.",
-          "default": "automatic",
+          "markdownDescription": "Set the language server for the extension to use. By default (in `auto` mode), the extension will use the native server if the active Ruff version is `v0.5.0` or greater, and will use `ruff-lsp` otherwise. `native` will force the extension to always use `ruff server`, and legacy will force the extension to always use `ruff-lsp`.",
+          "default": "auto",
           "enum": [
-            "automatic",
+            "auto",
             "native",
             "legacy"
           ],

--- a/package.json
+++ b/package.json
@@ -63,8 +63,21 @@
   "contributes": {
     "configuration": {
       "properties": {
+        "ruff.languageServer": {
+          "type": "string",
+          "markdownDescription": "Set the language server for the extension to use. By default (in `automatic mode`), the extension will use the native server if the active Ruff version is `v0.4.5` or greater, and will use `ruff-lsp` otherwise. `native` will force the extension to always use `ruff server`, and legacy will force the extension to always use `ruff-lsp`.",
+          "default": "automatic",
+          "enum": [
+            "automatic",
+            "native",
+            "legacy"
+          ],
+          "scope": "window"
+        },
         "ruff.nativeServer": {
           "default": false,
+          "deprecationMessage": "Deprecated: use `ruff.languageServer` instead.",
+          "markdownDeprecationMessage": "**Deprecated**: use `ruff.languageServer` instead.",
           "markdownDescription": "Use the integrated Rust-based language server, available now in Beta.",
           "scope": "window",
           "type": "boolean"

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -17,3 +17,4 @@ export const EXPERIMENTAL_SERVER_SCRIPT_PATH = path.join(
 );
 export const RUFF_SERVER_CMD = "server";
 export const RUFF_SERVER_REQUIRED_ARGS = ["--preview"];
+export const RUFF_VERSION_ARGS = ["--version"];

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -30,7 +30,7 @@ import { isVirtualWorkspace } from "./vscodeapi";
 import { promisify } from "util";
 import { exec } from "child_process";
 
-const MIN_NATIVE_VERSION = [0, 4, 5];
+const MIN_NATIVE_VERSION = [0, 5, 0];
 
 export type IInitOptions = {
   settings: ISettings[];
@@ -44,6 +44,7 @@ async function createNativeServer(
   outputChannel: LogOutputChannel,
   initializationOptions: IInitOptions,
 ): Promise<LanguageClient> {
+  traceInfo("Using the native language server");
   let serverOptions: ServerOptions;
   // If the user provided a binary path, we'll try to call that path directly.
   if (settings.path[0]) {
@@ -99,6 +100,7 @@ async function createLegacyServer(
   outputChannel: LogOutputChannel,
   initializationOptions: IInitOptions,
 ): Promise<LanguageClient> {
+  traceInfo("Using the legacy language server");
   const command = settings.interpreter[0];
   const cwd = settings.cwd;
 
@@ -231,7 +233,7 @@ export async function restartServer(
 
 async function getRuffVersion(settings: ISettings): Promise<[number, number, number]> {
   let command;
-  if (settings.path[0]) {
+  if (settings.path[0] != null) {
     command = `${settings.path[0]} ${RUFF_VERSION_ARGS.join(" ")}`;
   } else {
     command = `${
@@ -245,9 +247,9 @@ async function getRuffVersion(settings: ISettings): Promise<[number, number, num
   });
   const versionRegex = /ruff (\d+).(\d+).(\d+)/;
   const matches = stdout.match(versionRegex) ?? [];
-  let major = Number(matches[1] ?? "X");
-  let minor = Number(matches[2] ?? "X");
-  let patch = Number(matches[3] ?? "X");
+  let major = parseInt(matches[1] ?? "X", 10);
+  let minor = parseInt(matches[2] ?? "X", 10);
+  let patch = parseInt(matches[3] ?? "X", 10);
   if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
     return [0, 0, 0];
   } else {

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -13,6 +13,8 @@ type Run = "onType" | "onSave";
 
 type ConfigPreference = "editorFirst" | "filesystemFirst" | "editorOnly";
 
+type LanguageServer = "automatic" | "native" | "legacy";
+
 type CodeAction = {
   disableRuleComment?: {
     enable?: boolean;
@@ -39,6 +41,7 @@ type Format = {
 
 export interface ISettings {
   nativeServer: boolean;
+  languageServer: LanguageServer;
   cwd: string;
   workspace: string;
   path: string[];
@@ -124,6 +127,7 @@ export async function getWorkspaceSettings(
 
   return {
     nativeServer: config.get<boolean>("nativeServer") ?? false,
+    languageServer: config.get<LanguageServer>("languageServer") ?? "automatic",
     cwd: workspace.uri.fsPath,
     workspace: workspace.uri.toString(),
     path: resolveVariables(config.get<string[]>("path") ?? [], workspace),
@@ -173,6 +177,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
   const config = getConfiguration(namespace);
   return {
     nativeServer: getGlobalValue<boolean>(config, "nativeServer", false),
+    languageServer: getGlobalValue<LanguageServer>(config, "languageServer", "automatic"),
     cwd: process.cwd(),
     workspace: process.cwd(),
     path: getGlobalValue<string[]>(config, "path", []),
@@ -217,6 +222,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.configuration`,
     `${namespace}.enable`,
     `${namespace}.nativeServer`,
+    `${namespace}.languageServer`,
     `${namespace}.fixAll`,
     `${namespace}.ignoreStandardLibrary`,
     `${namespace}.importStrategy`,


### PR DESCRIPTION
## Summary

The native server is now automatically enabled when using Ruff `v0.4.5` or later. The extension can also be configured to always use the native server (or never use it) via the new `languageServer` setting.

## Test Plan

1. Uninstall any local Ruff executables from your system.
2. Launch the extension. It should be using `ruff server` by default, since the extension uses a compatible bundled version (you can distinguish whether or not the native server is running by the log output)
3. Switch the `languageServer` setting to `legacy`. The extension should now be using `ruff-lsp`.
4. Switch the `languageServer` setting back to `automatic`.
5. Install Ruff version `v0.4.5`. Confirm that the extension uses this executable, and that it's using the native server.
6. Install a Ruff version before `v0.4.5`. Confirm that the extension uses this executable, and that it's using `ruff-lsp`.
