### PR TITLE
Support `auto` enablement of Ruff server

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,27 @@
     "configuration": {
       "properties": {
         "ruff.nativeServer": {
-          "default": false,
-          "markdownDescription": "Use the integrated Rust-based language server, available now in Beta.",
+          "default": "auto",
+          "type": [
+            "boolean",
+            "string"
+          ],
           "scope": "window",
-          "type": "boolean"
+          "markdownDescription": "Whether to use the native language server, [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) or automatically decide between the two based on the Ruff version and extension settings.",
+          "enum": [
+            "on",
+            "off",
+            "auto",
+            true,
+            false
+          ],
+          "markdownEnumDescriptions": [
+            "Use the native language server. A warning will be displayed if deprecated settings are detected.",
+            "Use [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). A warning will be displayed if settings specific to the native server are detected.",
+            "Automatically select between the native language server and [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) based on the following conditions:\n1. If the Ruff version is >= `0.5.2`, use the native language server unless any deprecated settings are detected. In that case, show a warning and use [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) instead.\n2. If the Ruff version is < `0.5.2`, use [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). A warning will be displayed if settings specific to the native server are detected.",
+            "Same as `on`.",
+            "Same as `off`."
+          ]
         },
         "ruff.configuration": {
           "default": null,

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,0 +1,60 @@
+/**
+ * Describes a semantic version with major, minor, and patch components.
+ */
+export type VersionInfo = {
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+/**
+ * Convert a version object to a string.
+ */
+export function versionToString(version: VersionInfo): string {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+/**
+ * Check if version `a` is greater than or equal to version `b`.
+ */
+function versionGte(a: VersionInfo, b: VersionInfo): boolean {
+  if (a.major > b.major) {
+    return true;
+  }
+  if (a.major === b.major) {
+    if (a.minor > b.minor) {
+      return true;
+    }
+    if (a.minor === b.minor) {
+      if (a.patch >= b.patch) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * The minimum version of the Ruff executable that supports the native server.
+ */
+export const MINIMUM_NATIVE_SERVER_VERSION: VersionInfo = { major: 0, minor: 3, patch: 5 };
+
+/**
+ * Check if the given version of the Ruff executable supports the native server.
+ */
+export function supportsNativeServer(version: VersionInfo): boolean {
+  return versionGte(version, MINIMUM_NATIVE_SERVER_VERSION);
+}
+
+/**
+ * The version of the Ruff executable that made the native server stable.
+ */
+export const NATIVE_SERVER_STABLE_VERSION: VersionInfo = { major: 0, minor: 5, patch: 0 };
+
+/**
+ * Check if the given version of the Ruff executable has the stable version of
+ * the native server.
+ */
+export function supportsStableNativeServer(version: VersionInfo): boolean {
+  return versionGte(version, NATIVE_SERVER_STABLE_VERSION);
+}


### PR DESCRIPTION
## Summary

Superseds #505 

This PR updates the `nativeServer` setting with new values `on | off | auto` based on the suggestion at https://github.com/astral-sh/ruff-vscode/pull/505#discussion_r1659606353.

For backwards compatibility, `on` and `off` are equivalent to `true` and `false` respectively.

### Logic

#### `"on"` / `true`
- Use the native server
- Show warning for “deprecated” settings

#### `"off"` / `false`
- Use `ruff-lsp`
- Show warning for “new” settings

#### `"auto"`
- If `ruff` version is < `0.5.2`
  - If any of the “new” settings are set, log at info level for those settings
  - Use `ruff-lsp`.
- If `ruff` version is ≥ `0.5.2`
  - If any of the “deprecated” settings are set, log at info level for those settings
    - Use `ruff-lsp`
  - Otherwise, use `ruff server`

<details><summary><b>Settings reference:</b></summary>

#### Global

Here, the scope represents the following:
* "both": setting is supported by both native server and `ruff-lsp`
* "new": setting is only supported by the native server
* "deprecated": setting is deprecated and isn't supported by the native server
* "server deprecated": setting is deprecated only in the native server but it's still accepted and use by the VS Code extension

Settings | Scope
-- | --
`enable` | both
`fixAll` | both
`organizeImports` | both
`importStrategy` | both
`showNotifications` | both
`showSyntaxErrors` | both
`configuration` | new
`configurationPreference` | new
`exclude` | new
`lineLength` | new
`logLevel` | new
`logFile` | new
`path` | server deprecated
`interpreter` | server deprecated
`ignoreStandardLibrary` | deprecated

#### `codeAction`

Settings | Scope
-- | --
`disableRuleComment.enable` | both
`fixViolation.enable` | both

#### `lint`

Settings | Scope
-- | --
`enable` | both
`preview` | new
`select` | new
`extendSelect` | new
`ignore` | new
`extendIgnore` | new
`args` | deprecated
`run` | deprecated

#### `format`

Settings |  Scope
-- | --
`preview` | new
`args` | deprecated

</details>

## Settings Preview

Preview of how the description of `nativeServer` setting renders:

### Auto-completion

<img width="974" alt="Screenshot 2024-07-05 at 10 33 07" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/e203525d-ce48-4a90-8964-ed18c0174a31">

### Hover on "auto"

<img width="998" alt="Screenshot 2024-07-05 at 10 33 45" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/3af13406-fddb-4ab6-b984-9d663830b39f">

### Hover on "on"

<img width="1021" alt="Screenshot 2024-07-05 at 10 34 24" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/53ce619f-ff2b-4c53-9ac0-f130aed6503d">

### Hover on "off"

<img width="992" alt="Screenshot 2024-07-05 at 10 34 37" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/4e03e316-1e02-4584-855d-c1dfa2a1fa33">

### Dropdown

https://github.com/astral-sh/ruff-vscode/assets/67177269/c09bb85c-e82b-4460-8ee5-960d29854389

## Test Plan

### Native server `on` with a unsupported settings

```jsonc
{
  "ruff.nativeServer": "on",
  // Deprecated
  "ruff.lint.args": ["--ignore=E501"],
}
```

Logs:
```
2024-07-05 10:51:30.360 [warning] Following settings are not supported with the native server: ["ruff.lint.args"]
2024-07-05 10:51:30.398 [info] Using the Ruff binary: /Users/dhruv/.local/bin/ruff
2024-07-05 10:51:30.407 [info] Found Ruff 0.5.0 at /Users/dhruv/.local/bin/ruff
2024-07-05 10:51:30.407 [info] Server run command: /Users/dhruv/.local/bin/ruff server --preview
```

Notification Preview:

<img width="572" alt="Screenshot 2024-07-05 at 10 51 12" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/2b37bc59-2b01-4953-acbc-c503d1f49069">

### Native server `off` with unsupported settings

```jsonc
{
  "ruff.nativeServer": "off",
  // Native server only
  "ruff.configuration": "~/playground/ruff/pyproject.toml",
  "ruff.lineLength": 70
}
```

Logs:
```
2024-07-05 10:52:56.653 [warning] Following settings are not supported with the legacy server (ruff-lsp): ["ruff.configuration","ruff.lineLength"]
2024-07-05 10:52:56.656 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/.venv/bin/python /Users/dhruv/work/astral/ruff-vscode/bundled/tool/server.py
```

Notification Preview:

<img width="569" alt="Screenshot 2024-07-05 at 10 52 49" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/f67db645-72d6-402f-8283-08d5b4b94d1a">

### Native server "auto" with non-stable version:

```jsonc
{
  "ruff.nativeServer": "auto"
}
```

Logs:
```
2024-07-05 10:57:53.003 [info] Using the Ruff binary: /Users/dhruv/.local/bin/ruff
2024-07-05 10:57:53.010 [info] Stable version of the native server requires Ruff 0.5.0, but found 0.4.10 at /Users/dhruv/.local/bin/ruff instead
2024-07-05 10:57:53.010 [info] Resolved 'ruff.nativeServer: auto' to use legacy (ruff-lsp) server
2024-07-05 10:57:53.011 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/.venv/bin/python /Users/dhruv/work/astral/ruff-vscode/bundled/tool/server.py
```

### Native server "auto" with non-stable version and native server settings:

```jsonc
{
  "ruff.nativeServer": "auto",
  // Native server only
  "ruff.configuration": "~/playground/ruff/pyproject.toml",
  "ruff.lineLength": 70
}
```

Logs:
```
2024-07-05 11:17:53.976 [info] Using the Ruff binary: /Users/dhruv/.local/bin/ruff
2024-07-05 11:17:53.987 [info] Stable version of the native server requires Ruff 0.5.0, but found 0.4.10 at /Users/dhruv/.local/bin/ruff instead
2024-07-05 11:17:53.987 [info] Native server settings found: ["ruff.configuration","ruff.lineLength"]
2024-07-05 11:17:53.987 [info] Resolved 'ruff.nativeServer: auto' to use legacy (ruff-lsp) server
2024-07-05 11:17:53.991 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/.venv/bin/python /Users/dhruv/work/astral/ruff-vscode/bundled/tool/server.py
```

### Native server "auto" with stable version and using native server settings:

```jsonc
{
  "ruff.nativeServer": "auto",
  // Native server only
  "ruff.configuration": "~/playground/ruff/pyproject.toml",
  "ruff.lineLength": 70
}
```

Logs:
```
2024-07-05 11:02:15.113 [info] Using the Ruff binary: /Users/dhruv/.local/bin/ruff
2024-07-05 11:02:15.316 [info] Resolved 'ruff.nativeServer: auto' to use native server
2024-07-05 11:02:15.316 [info] Found Ruff 0.5.0 at /Users/dhruv/.local/bin/ruff
2024-07-05 11:02:15.316 [info] Server run command: /Users/dhruv/.local/bin/ruff server --preview
```

### Native server "auto" with stable version and using legacy server settings:

```jsonc
{
  "ruff.nativeServer": "auto",
  // Deprecated
  "ruff.ignoreStandardLibrary": true,
  "ruff.lint.args": ["--ignore=E501"]
}
```

Logs:
```
2024-07-05 11:06:22.133 [info] Using the Ruff binary: /Users/dhruv/.local/bin/ruff
2024-07-05 11:06:22.136 [info] Legacy server settings found: ["ruff.ignoreStandardLibrary","ruff.lint.args"]
2024-07-05 11:06:22.136 [info] Resolved 'ruff.nativeServer: auto' to use legacy (ruff-lsp) server
2024-07-05 11:06:22.140 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/.venv/bin/python /Users/dhruv/work/astral/ruff-vscode/bundled/tool/server.py
```

### Native server "auto" with stable version and using both native and legacy server settings:

```jsonc
{
  "ruff.nativeServer": "auto",
  // Native server only
  "ruff.configuration": "~/playground/ruff/pyproject.toml",
  "ruff.lineLength": 70,
  // Deprecated
  "ruff.ignoreStandardLibrary": true,
  "ruff.lint.args": ["--ignore=E501"]
}
```

Logs:
```
2024-07-05 11:19:12.425 [info] Using the Ruff binary: /Users/dhruv/.local/bin/ruff
2024-07-05 11:19:12.619 [info] Legacy server settings found: ["ruff.ignoreStandardLibrary","ruff.lint.args"]
2024-07-05 11:19:12.619 [info] Resolved 'ruff.nativeServer: auto' to use legacy (ruff-lsp) server
2024-07-05 11:19:12.620 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/.venv/bin/python /Users/dhruv/work/astral/ruff-vscode/bundled/tool/server.py
```