### PR TITLE
Show server kind in the status bar

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -35,7 +35,7 @@ import {
   supportsStableNativeServer,
   NATIVE_SERVER_STABLE_VERSION,
 } from "./version";
-import { updateStatus } from "./status";
+import { updateServerKind, updateStatus } from "./status";
 import { getProjectRoot } from "./utilities";
 import { isVirtualWorkspace } from "./vscodeapi";
 import { exec } from "child_process";
@@ -373,6 +373,7 @@ async function createServer(
     outputChannel,
   );
 
+  updateServerKind(useNativeServer);
   if (useNativeServer) {
     return createNativeServer(
       settings,

--- a/src/common/status.ts
+++ b/src/common/status.ts
@@ -7,6 +7,8 @@ import { Command } from "vscode-languageclient";
 import { getDocumentSelector } from "./utilities";
 
 let _status: LanguageStatusItem | undefined;
+let _serverKind: "native" | "ruff-lsp" | undefined;
+
 export function registerLanguageStatusItem(id: string, name: string, command: string): Disposable {
   _status = createLanguageStatusItem(id, getDocumentSelector());
   _status.name = name;
@@ -21,6 +23,10 @@ export function registerLanguageStatusItem(id: string, name: string, command: st
   };
 }
 
+export function updateServerKind(native: boolean): void {
+  _serverKind = native ? "native" : "ruff-lsp";
+}
+
 export function updateStatus(
   status: string | undefined,
   severity: LanguageStatusSeverity,
@@ -28,7 +34,11 @@ export function updateStatus(
   detail?: string,
 ): void {
   if (_status) {
-    _status.text = status && status.length > 0 ? `${_status.name}: ${status}` : `${_status.name}`;
+    let name = _status.name;
+    if (_serverKind) {
+      name = `${name} (${_serverKind})`;
+    }
+    _status.text = status && status.length > 0 ? `${name}: ${status}` : `${name}`;
     _status.severity = severity;
     _status.busy = busy ?? false;
     _status.detail = detail;


### PR DESCRIPTION
## Summary

This PR updates the status item to show the chosen server in the status bar. The value would be either `Ruff (native)` or `Ruff (ruff-lsp)`.

## Test Plan

When `nativeServer` is `true`:

<img width="290" alt="Screenshot 2024-07-08 at 15 50 46" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/0c1048bc-905a-4e4c-9014-8c3ffb93c4fd">

When `nativeServer` is `false`:

<img width="304" alt="Screenshot 2024-07-08 at 15 51 00" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/8a8c4afd-bcbf-4f57-81b2-9b11c617e5f0">
