### PR TITLE
Add support for untrusted workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,15 @@
     "ms-python.python"
   ],
   "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "restrictedConfigurations": [
+        "ruff.path",
+        "ruff.importStrategy",
+        "ruff.interpreter",
+        "ruff.configuration"
+      ]
+    },
     "virtualWorkspaces": {
       "supported": false,
       "description": "Virtual Workspaces are not supported by the Ruff extension."

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode";
 import {
   ConfigurationChangeEvent,
   ConfigurationScope,
@@ -116,7 +117,7 @@ export async function getWorkspaceSettings(
   const config = getConfiguration(namespace, workspace.uri);
 
   let interpreter: string[] = getInterpreterFromSetting(namespace, workspace) ?? [];
-  if (interpreter.length === 0) {
+  if (interpreter.length === 0 && vscode.workspace.isTrusted) {
     interpreter = (await getInterpreterDetails(workspace.uri)).path ?? [];
   }
 

--- a/src/common/vscodeapi.ts
+++ b/src/common/vscodeapi.ts
@@ -34,7 +34,7 @@ export function registerCommand(
   return commands.registerCommand(command, callback, thisArg);
 }
 
-export const { onDidChangeConfiguration } = workspace;
+export const { onDidChangeConfiguration, onDidGrantWorkspaceTrust } = workspace;
 
 export function isVirtualWorkspace(): boolean {
   const isVirtual =


### PR DESCRIPTION
## Summary

This PR adds support for [untrusted workspaces](https://code.visualstudio.com/docs/editor/workspace-trust).

This wasn't possible with `ruff-lsp` because it always required a Python interpreter to run but we can support it with the native server.

resolves: #510

## Preview

Restricted configuration view:

<img width="1199" alt="Screenshot 2024-07-11 at 17 38 57" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/55947b1b-d423-4325-84f8-534fd6a86838">

Switching from an untrusted workspace to a trusted one:

Config:
```json
{
  "ruff.nativeServer": "auto",
  "ruff.path": ["/Users/dhruv/work/astral/ruff/target/debug/ruff"]
}
```

Here, the `ruff.path` configuration isn't considered. But, as soon as we trust the workspace, the server is restarted using the `ruff.path` setting as seen in the logs.

https://github.com/astral-sh/ruff-vscode/assets/67177269/954f8b65-2ae1-4424-ac89-fdf0d40f4fd9


## Test Plan

Explicitly using native server:

```json
{
	"ruff.nativeServer": "on"
}
```

Logs:
```
2024-07-11 17:37:18.167 [info] Workspace is not trusted, using bundled executable: /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff
2024-07-11 17:37:18.167 [info] Found Ruff 0.5.0 at /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff
2024-07-11 17:37:18.167 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff server --preview
```

Explicitly using `ruff-lsp`:
```json
{
	"ruff.nativeServer": "off"
}
```

```
2024-07-11 17:41:31.432 [warning] Cannot use the legacy server (ruff-lsp) in an untrusted workspace; switching to the native server using the bundled executable.
2024-07-11 17:41:31.432 [info] Workspace is not trusted, using bundled executable: /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff
2024-07-11 17:41:31.451 [info] Found Ruff 0.5.0 at /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff
2024-07-11 17:41:31.452 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff server --preview
```

Notification preview:
<img width="468" alt="Screenshot 2024-07-11 at 17 41 24" src="https://github.com/astral-sh/ruff-vscode/assets/67177269/88865ce1-1289-44e5-8daa-1b2b81c42139">

Using `auto` behavior:
```json
{
	"ruff.nativeServer": "auto"
}
```

Logs:
```
2024-07-11 17:41:57.784 [info] Resolved 'ruff.nativeServer: auto' to use the native server in an untrusted workspace
2024-07-11 17:41:57.784 [info] Workspace is not trusted, using bundled executable: /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff
2024-07-11 17:41:57.794 [info] Found Ruff 0.5.0 at /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff
2024-07-11 17:41:57.795 [info] Server run command: /Users/dhruv/work/astral/ruff-vscode/bundled/libs/bin/ruff server --preview
```