### PR TITLE
Add TypeScript tests to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,9 +54,5 @@ jobs:
         run: npm run pretest
         shell: bash
       - name: Run tests
-        run: |
-          ls -la out/
-          ls -la node_modules/
-          ls -la bundled/libs
-          xvfb-run npm run tests
+        run: xvfb-run npm run tests
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,33 @@ jobs:
         run: just check
       - name: Run tests
         run: just test
+
+  ts-tests:
+    name: TypeScript Tests
+    runs-on: ubuntu-latest
+    env:
+      UV_SYSTEM_PYTHON: 1
+    steps:
+      - uses: extractions/setup-just@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.7"
+      - uses: hynek/setup-cached-uv@v1
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          just setup
+          npm ci
+        shell: bash
+      - name: Compile tests
+        run: npm run pretest
+        shell: bash
+      - name: Run tests
+        run: |
+          ls -la out/
+          ls -la node_modules/
+          ls -la bundled/libs
+          xvfb-run npm run tests
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@
 **/.venv/
 **/__pycache__/
 **/dist/
-**/out/
 **/node_modules/
 *.vsix
 *.pyc
 /bundled/libs/
 .vscode-test/
+out/

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,10 +4,10 @@
 **/.venv/
 **/__pycache__/
 **/dist/
-**/out/
 **/node_modules/
 *.vsix
 *.pyc
 .mypy_cache/**
 /bundled/libs/
 .vscode-test/
+out/

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -5,6 +5,7 @@ module.exports = defineConfig({
   workspaceFolder: "./src/testFixture",
   mocha: {
     ui: "tdd",
-    timeout: 10000,
+    color: true,
+    timeout: 20000,
   },
 });

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,5 +23,7 @@ requirements.txt
 scripts/
 src/
 tests/
+out/
+.vscode-test/
 tsconfig.json
 webpack.config.js

--- a/justfile
+++ b/justfile
@@ -15,8 +15,9 @@ install:
 test: setup
   python -m unittest
 
-e2e-test: install
-  npm run test
+e2e-tests: setup
+  npm run pretest
+  npm run tests
 
 check:
   ruff check ./bundled/tool ./build ./tests
@@ -34,3 +35,9 @@ fmt:
 build-package: setup
   npm ci
   npm run vsce-package
+
+clean:
+  rm -rf out
+  rm -rf node_modules
+  rm -rf .vscode-test
+  rm -rf bundled/libs

--- a/package.json
+++ b/package.json
@@ -63,13 +63,15 @@
     "fmt": "prettier -w .",
     "fmt-check": "prettier --check .",
     "lint": "eslint src --ext ts",
-    "compile": "tsc",
+    "compile": "webpack",
+    "compile-tests": "tsc -p . --outDir out",
     "tsc": "tsc --noEmit",
     "package": "webpack --mode production --devtool source-map --config ./webpack.config.js",
     "watch": "webpack --watch",
     "vsce-package": "vsce package -o ruff.vsix",
     "vscode:prepublish": "npm run package",
-    "test": "npm run compile && vscode-test"
+    "pretest": "npm run compile-tests && npm run compile",
+    "tests": "vscode-test"
   },
   "contributes": {
     "configuration": {

--- a/src/common/log/logging.ts
+++ b/src/common/log/logging.ts
@@ -37,21 +37,36 @@ export function registerLogger(logChannel: LogOutputChannel): Disposable {
 }
 
 export function traceLog(...args: Arguments): void {
+  if (process.env.CI === "true") {
+    console.log(...args);
+  }
   channel?.traceLog(...args);
 }
 
 export function traceError(...args: Arguments): void {
+  if (process.env.CI === "true") {
+    console.log(...args);
+  }
   channel?.traceError(...args);
 }
 
 export function traceWarn(...args: Arguments): void {
+  if (process.env.CI === "true") {
+    console.log(...args);
+  }
   channel?.traceWarn(...args);
 }
 
 export function traceInfo(...args: Arguments): void {
+  if (process.env.CI === "true") {
+    console.log(...args);
+  }
   channel?.traceInfo(...args);
 }
 
 export function traceVerbose(...args: Arguments): void {
+  if (process.env.CI === "true") {
+    console.log(...args);
+  }
   channel?.traceVerbose(...args);
 }

--- a/src/test/e2e.test.ts
+++ b/src/test/e2e.test.ts
@@ -3,6 +3,8 @@ import * as assert from "assert";
 import { getDocumentUri, activateExtension, sleep } from "./helper";
 
 suite("E2E tests", () => {
+  const TIMEOUT = 5000;
+
   teardown(async () => {
     await vscode.commands.executeCommand("workbench.action.closeAllEditors");
   });
@@ -14,16 +16,23 @@ suite("E2E tests", () => {
     const document = await vscode.workspace.openTextDocument(documentUri);
     await vscode.window.showTextDocument(document);
 
+    const editor = vscode.window.activeTextEditor;
+    assert.ok(editor, "No active text editor");
+    assert.ok(
+      editor.document.uri.fsPath.endsWith("diagnostics.py"),
+      "Active text editor is not diagnostics.py",
+    );
+
     let actualDiagnostics = vscode.languages.getDiagnostics(documentUri);
     if (actualDiagnostics.length === 0) {
       // Wait for diagnostics to be computed
-      let timeout = 1000;
+      let timeout = TIMEOUT;
       while (actualDiagnostics.length === 0 && timeout > 0) {
         await sleep(100);
         actualDiagnostics = vscode.languages.getDiagnostics(documentUri);
         timeout -= 100;
       }
-      assert.ok(actualDiagnostics.length > 0, "No diagnostics provided in 1 second");
+      assert.ok(actualDiagnostics.length > 0, `No diagnostics provided in ${TIMEOUT}ms`);
     }
 
     actualDiagnostics = actualDiagnostics.sort((a, b) => {

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -8,7 +8,11 @@ export async function activateExtension() {
   if (extension === undefined) {
     throw new Error(`Extension ${EXTENSION_ID} not found`);
   }
-  await extension.activate();
+  try {
+    await extension.activate();
+  } catch (e) {
+    console.error(`Failed to activate the extension: ${e}`);
+  }
 }
 
 export async function sleep(ms: number) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "ES2020",
     "lib": ["ES2020"],
     "sourceMap": true,
-    "outDir": "out",
     "rootDir": "src",
     "strict": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Summary

This PR adds the TypeScript tests to the CI aka E2E tests for Linux operating system. I tried to add it for Windows but those were failing for reasons not known to me.

## Test Plan

`npm run tests`
