### PR TITLE
Avoid querying the Python extension for the interpreter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     restartInProgress = true;
 
-    if (!vscode.workspace.isTrusted) {
+    if (!vscode.workspace.isTrusted || process.env.CI == "true") {
       lsClient = await restartServer(serverId, serverName, outputChannel, lsClient);
 
       restartInProgress = false;
@@ -257,7 +257,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   setImmediate(async () => {
-    if (vscode.workspace.isTrusted) {
+    if (vscode.workspace.isTrusted && process.env.CI == undefined) {
       const interpreter = getInterpreterFromSetting(serverId);
       if (interpreter === undefined || interpreter.length === 0) {
         traceLog(`Python extension loading`);

--- a/src/testFixture/.vscode/settings.json
+++ b/src/testFixture/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  // Always use the bundled Ruff binary for the tests.
+  // Always use the native server and bundled Ruff binary for the tests.
+  "ruff.nativeServer": "on",
   "ruff.importStrategy": "useBundled",
 
   // Ruff's extension depends on the Python extension which also provides a language server,


### PR DESCRIPTION
## Summary

Fix the CI failure on `main`. I think the tests are currently unpredictable in the sense that the tests could begin _before_ the server starts which then creates the failure. The main reason I believe this is happening is because the extension uses a PubSub mechanism here:

https://github.com/astral-sh/ruff-vscode/blob/80d1b13a80ac99afb96a34ae6358d893158a65b8/src/common/python.ts#L250-L259

This change is so that it never hits this by always testing with the bundled executable and always using the native server.

## Test Plan

I don't really have a good way to test this until it's being triggered multiple times which will verify the consistency now.