### PR TITLE
Add `logLevel` and `logFile` extension setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,13 +101,13 @@
         },
         "ruff.configuration": {
           "default": null,
-          "markdownDescription": "Path to a `ruff.toml` or `pyproject.toml` file to use for configuration. By default, Ruff will discover configuration for each project from the filesystem, mirroring the behavior of the Ruff CLI. This setting is used only by the native server.",
+          "markdownDescription": "Path to a `ruff.toml` or `pyproject.toml` file to use for configuration. By default, Ruff will discover configuration for each project from the filesystem, mirroring the behavior of the Ruff CLI.\n\n**This setting is used only by the native server.**",
           "scope": "window",
           "type": "string"
         },
         "ruff.args": {
           "default": [],
-          "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`. This setting is not supported by the native server.",
+          "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.\n\n**This setting is not supported by the native server.**",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#ruff.lint.args` instead.",
           "deprecationMessage": "Deprecated: Please use ruff.lint.args instead.",
           "items": {
@@ -118,7 +118,7 @@
         },
         "ruff.lint.args": {
           "default": [],
-          "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`. This setting is not supported by the native server.",
+          "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.\n\n**This setting is not supported by the native server.**",
           "items": {
             "type": "string"
           },
@@ -127,13 +127,13 @@
         },
         "ruff.lint.preview": {
           "default": null,
-          "markdownDescription": "Enable [preview mode](https://docs.astral.sh/ruff/settings/#lint_preview) for the linter; enables unstable rules and fixes. This setting is used only by the native server.",
+          "markdownDescription": "Enable [preview mode](https://docs.astral.sh/ruff/settings/#lint_preview) for the linter; enables unstable rules and fixes.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": "boolean"
         },
         "ruff.lint.select": {
           "default": null,
-          "markdownDescription": "Set rule codes to enable. Use `ALL` to enable all rules. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_select) for more details. This setting is used only by the native server.",
+          "markdownDescription": "Set rule codes to enable. Use `ALL` to enable all rules. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_select) for more details.\n\n**This setting is used only by the native server.**",
           "examples": [
             [
               "E4",
@@ -150,7 +150,7 @@
         },
         "ruff.lint.extendSelect": {
           "default": null,
-          "markdownDescription": "Enable additional rule codes on top of existing configuration, instead of overriding it. Use `ALL` to enable all rules. This setting is used only by the native server.",
+          "markdownDescription": "Enable additional rule codes on top of existing configuration, instead of overriding it. Use `ALL` to enable all rules.\n\n**This setting is used only by the native server.**",
           "items": {
             "type": "string"
           },
@@ -159,7 +159,7 @@
         },
         "ruff.lint.ignore": {
           "default": null,
-          "markdownDescription": "Set rule codes to disable. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_ignore) for more details. This setting is used only by the native server.",
+          "markdownDescription": "Set rule codes to disable. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_ignore) for more details.\n\n**This setting is used only by the native server.**",
           "items": {
             "type": "string"
           },
@@ -168,7 +168,7 @@
         },
         "ruff.run": {
           "default": "onType",
-          "markdownDescription": "Run Ruff on every keystroke (`onType`) or on save (`onSave`). This setting is not supported by the native server.",
+          "markdownDescription": "Run Ruff on every keystroke (`onType`) or on save (`onSave`).\n\n**This setting is not supported by the native server.**",
           "markdownDeprecationMessage": "**Deprecated**: Please use `#ruff.lint.run` instead.",
           "deprecationMessage": "Deprecated: Please use ruff.lint.run instead.",
           "enum": [
@@ -184,7 +184,7 @@
         },
         "ruff.lint.run": {
           "default": "onType",
-          "markdownDescription": "Run Ruff on every keystroke (`onType`) or on save (`onSave`). This setting is not supported by the native server.",
+          "markdownDescription": "Run Ruff on every keystroke (`onType`) or on save (`onSave`).\n\n**This setting is not supported by the native server.**",
           "enum": [
             "onType",
             "onSave"
@@ -204,7 +204,7 @@
         },
         "ruff.format.args": {
           "default": [],
-          "markdownDescription": "Additional command-line arguments to pass to `ruff format`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`. This setting is not supported by the native server.",
+          "markdownDescription": "Additional command-line arguments to pass to `ruff format`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.\n\n**This setting is not supported by the native server.**",
           "items": {
             "type": "string"
           },
@@ -213,7 +213,7 @@
         },
         "ruff.format.preview": {
           "default": null,
-          "markdownDescription": "Enable [preview mode](https://docs.astral.sh/ruff/settings/#format_preview) for the formatter; enables unstable formatting. This setting is used only by the native server.",
+          "markdownDescription": "Enable [preview mode](https://docs.astral.sh/ruff/settings/#format_preview) for the formatter; enables unstable formatting.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": "boolean"
         },
@@ -311,6 +311,25 @@
           "scope": "window",
           "type": "boolean"
         },
+        "ruff.logLevel": {
+          "default": null,
+          "markdownDescription": "Controls the log level of the language server.\n\n**This setting is used only by the native server.**",
+          "enum": [
+            "error",
+            "warning",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "scope": "window",
+          "type": "string"
+        },
+        "ruff.logFile": {
+          "default": null,
+          "markdownDescription": "Path to the log file for the language server.\n\n**This setting is used only by the native server.**",
+          "scope": "window",
+          "type": "string"
+        },
         "ruff.trace.server": {
           "type": "string",
           "enum": [
@@ -344,7 +363,7 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Set paths for the linter and formatter to ignore. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_exclude) for more details. This setting is used only by the native server.",
+          "markdownDescription": "Set paths for the linter and formatter to ignore. See [the documentation](https://docs.astral.sh/ruff/settings/#lint_exclude) for more details.\n\n**This setting is used only by the native server.**",
           "type": "array",
           "scope": "resource"
         },
@@ -352,7 +371,7 @@
           "default": null,
           "minimum": 1,
           "maximum": 320,
-          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0 and less than or equal to 320. This setting is used only by the native server.",
+          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0 and less than or equal to 320.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": [
             "integer",
@@ -370,7 +389,7 @@
             "An alternative strategy - configuration set in `.toml` files takes priority over configuration set in the editor.",
             "An alternative strategy - configuration set in `.toml` files is ignored entirely."
           ],
-          "markdownDescription": "The preferred method of resolving configuration in the editor with local configuration froml `.toml` files. This setting is used only by the native server.",
+          "markdownDescription": "The preferred method of resolving configuration in the editor with local configuration froml `.toml` files.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": "string",
           "default": "editorFirst"

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -16,6 +16,8 @@ type ConfigPreference = "editorFirst" | "filesystemFirst" | "editorOnly";
 
 type NativeServer = boolean | "on" | "off" | "auto";
 
+type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
+
 type CodeAction = {
   disableRuleComment?: {
     enable?: boolean;
@@ -60,6 +62,8 @@ export interface ISettings {
   lineLength?: number;
   configurationPreference?: ConfigPreference;
   showSyntaxErrors: boolean;
+  logLevel?: LogLevel;
+  logFile?: string;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -161,6 +165,8 @@ export async function getWorkspaceSettings(
     configurationPreference:
       config.get<ConfigPreference>("configurationPreference") ?? "editorFirst",
     showSyntaxErrors: config.get<boolean>("showSyntaxErrors") ?? true,
+    logLevel: config.get<LogLevel>("logLevel"),
+    logFile: config.get<string>("logFile"),
   };
 }
 
@@ -211,6 +217,8 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
       "editorFirst",
     ),
     showSyntaxErrors: getGlobalValue<boolean>(config, "showSyntaxErrors", true),
+    logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
+    logFile: getOptionalGlobalValue<string>(config, "logFile"),
   };
 }
 
@@ -241,6 +249,8 @@ export function checkIfConfigurationChanged(
     `${namespace}.lineLength`,
     `${namespace}.configurationPreference`,
     `${namespace}.showSyntaxErrors`,
+    `${namespace}.logLevel`,
+    `${namespace}.logFile`,
     // Deprecated settings (prefer `lint.args`, etc.).
     `${namespace}.args`,
     `${namespace}.run`,

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -1,26 +1,8 @@
 import * as fs from "fs-extra";
 import * as path from "path";
-import { LogLevel, Uri, WorkspaceFolder } from "vscode";
-import { Trace } from "vscode-jsonrpc/node";
+import { Uri, WorkspaceFolder } from "vscode";
 import { DocumentSelector } from "vscode-languageclient";
 import { getWorkspaceFolders, isVirtualWorkspace } from "./vscodeapi";
-
-function logLevelToTrace(logLevel: LogLevel): Trace {
-  switch (logLevel) {
-    case LogLevel.Error:
-    case LogLevel.Warning:
-    case LogLevel.Info:
-      return Trace.Messages;
-
-    case LogLevel.Debug:
-    case LogLevel.Trace:
-      return Trace.Verbose;
-
-    case LogLevel.Off:
-    default:
-      return Trace.Off;
-  }
-}
 
 export async function getProjectRoot(): Promise<WorkspaceFolder> {
   const workspaces: readonly WorkspaceFolder[] = getWorkspaceFolders();


### PR DESCRIPTION
## Summary

This PR adds `ruff.logLevel` and `ruff.logFile` settings to the VS Code extension which corresponds to the same for the `ruff server`. Without these, there's no way to configure the log level and the destination for the log messages unlike other editors.

## Test Plan

Using the following config:
```json
{
  "ruff.logLevel": "debug",
  "ruff.logFile": "~/playground/ruff/server.logs",
  "ruff.trace.server": "messages"
}
```

I confirmed that it outputs the logs messages at the specified location.