### PR TITLE
Avoid passing `--preview` flag for stable `ruff server`

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -61,6 +61,7 @@ export const FIND_RUFF_BINARY_SCRIPT_PATH = path.join(
 export const RUFF_SERVER_SUBCOMMAND = "server";
 
 /**
- * Required arguments for the `ruff server` command.
+ * Arguments for the `ruff server` command required when it's under preview i.e.,
+ * not yet stabilized.
  */
-export const RUFF_SERVER_REQUIRED_ARGS = ["--preview"];
+export const RUFF_SERVER_PREVIEW_ARGS = ["--preview"];

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -11,7 +11,7 @@ import {
 import {
   BUNDLED_RUFF_EXECUTABLE,
   DEBUG_SERVER_SCRIPT_PATH,
-  RUFF_SERVER_REQUIRED_ARGS,
+  RUFF_SERVER_PREVIEW_ARGS,
   RUFF_SERVER_SUBCOMMAND,
   RUFF_LSP_SERVER_SCRIPT_PATH,
   FIND_RUFF_BINARY_SCRIPT_PATH,
@@ -176,7 +176,12 @@ async function createNativeServer(
     return Promise.reject();
   }
 
-  const ruffServerArgs = [RUFF_SERVER_SUBCOMMAND, ...RUFF_SERVER_REQUIRED_ARGS];
+  let ruffServerArgs: string[];
+  if (supportsStableNativeServer(ruffVersion)) {
+    ruffServerArgs = [RUFF_SERVER_SUBCOMMAND];
+  } else {
+    ruffServerArgs = [RUFF_SERVER_SUBCOMMAND, ...RUFF_SERVER_PREVIEW_ARGS];
+  }
   traceInfo(`Server run command: ${[ruffBinaryPath, ...ruffServerArgs].join(" ")}`);
 
   let serverOptions = {


### PR DESCRIPTION
## Summary

This PR updates the logic to avoid passing the `--preview` flag to the `ruff server` command when the Ruff version contains the stabilized server. 

## Test Plan

I build the latest `main` from https://github.com/astral-sh/ruff which now removes the requirement of `--preview` flag and updated the `NATIVE_SERVER_STABLE_VERSION` flag in the extension to use `0.5.2` instead.

I checked the log messages to see when it's passing the `--preview` flag.