### PR TITLE
Fix typo in ruff.configurationPreference markdownDescription

### DIFF
--- a/package.json
+++ b/package.json
@@ -389,7 +389,7 @@
             "An alternative strategy - configuration set in `.toml` files takes priority over configuration set in the editor.",
             "An alternative strategy - configuration set in `.toml` files is ignored entirely."
           ],
-          "markdownDescription": "The preferred method of resolving configuration in the editor with local configuration froml `.toml` files.\n\n**This setting is used only by the native server.**",
+          "markdownDescription": "The preferred method of resolving configuration in the editor with local configuration from `.toml` files.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": "string",
           "default": "editorFirst"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Hi, this PR fixes a typo in the `markdownDescription` of the `ruff.configurationPreference` setting.

`froml` -> `from`

## Test Plan

<!-- How was it tested? -->
N/A