### PR TITLE
Use `ruff.interpreter` from workspace settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
         "ruff.interpreter": {
           "default": [],
           "markdownDescription": "Path to a Python interpreter to use to run the LSP server.",
-          "scope": "window",
+          "scope": "resource",
           "items": {
             "type": "string"
           },

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -67,13 +67,13 @@ export async function runPythonExtensionCommand(command: string, ...rest: any[])
   return await commands.executeCommand(command, ...rest);
 }
 
-export function checkVersion(resolved: ResolvedEnvironment | undefined): boolean {
-  const version = resolved?.version;
+export function checkVersion(resolved: ResolvedEnvironment): boolean {
+  const version = resolved.version;
   if (version?.major === 3 && version?.minor >= 7) {
     return true;
   }
   traceError(`Python version ${version?.major}.${version?.minor} is not supported.`);
-  traceError(`Selected python path: ${resolved?.executable.uri?.fsPath}`);
+  traceError(`Selected python path: ${resolved.executable.uri?.fsPath}`);
   traceError("Supported versions are 3.7 and above.");
   return false;
 }

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -24,7 +24,6 @@ import {
   getGlobalSettings,
   getUserSetLegacyServerSettings,
   getUserSetNativeServerSettings,
-  getWorkspaceSettings,
   ISettings,
 } from "./settings";
 import {
@@ -36,7 +35,6 @@ import {
   NATIVE_SERVER_STABLE_VERSION,
 } from "./version";
 import { updateServerKind, updateStatus } from "./status";
-import { getProjectRoot } from "./utilities";
 import { isVirtualWorkspace } from "./vscodeapi";
 import { execFile } from "child_process";
 import which = require("which");
@@ -412,6 +410,8 @@ async function createServer(
 
 let _disposables: Disposable[] = [];
 export async function restartServer(
+  projectRoot: vscode.WorkspaceFolder,
+  workspaceSettings: ISettings,
   serverId: string,
   serverName: string,
   outputChannel: LogOutputChannel,
@@ -425,9 +425,6 @@ export async function restartServer(
   }
 
   updateStatus(undefined, LanguageStatusSeverity.Information, true);
-
-  const projectRoot = await getProjectRoot();
-  const workspaceSettings = await getWorkspaceSettings(serverId, projectRoot);
 
   const extensionSettings = await getExtensionSettings(serverId);
   const globalSettings = await getGlobalSettings(serverId);

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -121,8 +121,12 @@ export async function getWorkspaceSettings(
   const config = getConfiguration(namespace, workspace.uri);
 
   let interpreter: string[] = getInterpreterFromSetting(namespace, workspace) ?? [];
-  if (interpreter.length === 0 && vscode.workspace.isTrusted) {
-    interpreter = (await getInterpreterDetails(workspace.uri)).path ?? [];
+  if (interpreter.length === 0) {
+    if (vscode.workspace.isTrusted) {
+      interpreter = (await getInterpreterDetails(workspace.uri)).path ?? [];
+    }
+  } else {
+    interpreter = resolveVariables(interpreter, workspace);
   }
 
   let configuration = config.get<string>("configuration") ?? null;
@@ -136,7 +140,7 @@ export async function getWorkspaceSettings(
     workspace: workspace.uri.toString(),
     path: resolveVariables(config.get<string[]>("path") ?? [], workspace),
     ignoreStandardLibrary: config.get<boolean>("ignoreStandardLibrary") ?? true,
-    interpreter: resolveVariables(interpreter, workspace),
+    interpreter,
     configuration,
     importStrategy: config.get<ImportStrategy>("importStrategy") ?? "fromEnvironment",
     codeAction: config.get<CodeAction>("codeAction") ?? {},


### PR DESCRIPTION
## Summary

This PR updates the scope of `ruff.interpreter` setting from `window` to `resource` in order to resolve the variables such as `${workspaceFolder}` if present.

In #551, what happens is that the Python extension fails to resolve the environment corresponding to that interpreter which causes the hang. The bug present in #551 was there for a very long time but it got visible because of https://github.com/astral-sh/ruff-vscode/commit/e665ec7be83b72f7586b30387cd87c8faf62b9e1. Before that commit, the extension would just move ahead and use the interpreter from the Python extension but now we explicitly stop moving ahead if it fails to resolve the environment corresponding to the interpreter.

For reference, the `vscode-black-formatter` extension also updated the scope of `ruff.interpreter` to be `resource` in https://github.com/microsoft/vscode-black-formatter/commit/5f2fc61b64ee5108fe5c25d2e7d55704051256a6.

fixes: #551

## Test Plan

### Relative paths are unresolved

```json
{
  "ruff.importStrategy": "fromEnvironment",
  "ruff.interpreter": [".venv/bin/python"]
}
```

Logs:

```
2024-07-24 08:50:37.182 [info] Using interpreter: .venv/bin/python
2024-07-24 08:50:39.240 [error] Unable to find any Python environment for the interpreter path: .venv/bin/python
```

Preview for the status bar:

<img width="1728" alt="Screenshot 2024-07-24 at 08 51 15" src="https://github.com/user-attachments/assets/e58d2691-cd94-4e03-8ec5-bbc65d1bf46f">

### Using VS Code specific variables

```json
{
  "ruff.importStrategy": "fromEnvironment",
  "ruff.interpreter": ["${workspaceFolder}/.venv/bin/python"]
}
```

Logs:
```
2024-07-24 08:51:43.272 [info] Using interpreter: /Users/dhruv/playground/ruff/.venv/bin/python
2024-07-24 08:51:43.306 [info] Using the Ruff binary: /Users/dhruv/playground/ruff/.venv/bin/ruff
2024-07-24 08:51:43.310 [info] Resolved 'ruff.nativeServer: auto' to use the native server
2024-07-24 08:51:43.313 [info] Found Ruff 0.5.4 at /Users/dhruv/playground/ruff/.venv/bin/ruff
2024-07-24 08:51:43.313 [info] Server run command: /Users/dhruv/playground/ruff/.venv/bin/ruff server
2024-07-24 08:51:43.313 [info] Server: Start requested.
```