### PR TITLE
Substitute environment variables in extension settings

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -35,7 +35,7 @@ import {
   NATIVE_SERVER_STABLE_VERSION,
 } from "./version";
 import { updateServerKind, updateStatus } from "./status";
-import { isVirtualWorkspace } from "./vscodeapi";
+import { getDocumentSelector } from "./utilities";
 import { execFile } from "child_process";
 import which = require("which");
 
@@ -188,14 +188,7 @@ async function createNativeServer(
 
   const clientOptions = {
     // Register the server for python documents
-    documentSelector: isVirtualWorkspace()
-      ? [{ language: "python" }]
-      : [
-          { scheme: "file", language: "python" },
-          { scheme: "untitled", language: "python" },
-          { scheme: "vscode-notebook", language: "python" },
-          { scheme: "vscode-notebook-cell", language: "python" },
-        ],
+    documentSelector: getDocumentSelector(),
     outputChannel: outputChannel,
     traceOutputChannel: outputChannel,
     revealOutputChannelOn: RevealOutputChannelOn.Never,
@@ -243,14 +236,7 @@ async function createLegacyServer(
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     // Register the server for python documents
-    documentSelector: isVirtualWorkspace()
-      ? [{ language: "python" }]
-      : [
-          { scheme: "file", language: "python" },
-          { scheme: "untitled", language: "python" },
-          { scheme: "vscode-notebook", language: "python" },
-          { scheme: "vscode-notebook-cell", language: "python" },
-        ],
+    documentSelector: getDocumentSelector(),
     outputChannel: outputChannel,
     traceOutputChannel: outputChannel,
     revealOutputChannelOn: RevealOutputChannelOn.Never,

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -92,6 +92,11 @@ function resolveVariables(
   getWorkspaceFolders().forEach((w) => {
     substitutions.set("${workspaceFolder:" + w.name + "}", w.uri.fsPath);
   });
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      substitutions.set("${env:" + key + "}", value);
+    }
+  }
 
   if (typeof value === "string") {
     let s = value;


### PR DESCRIPTION
## Summary

This PR updates the `resolveVariables` to consider environment variables.

Reference: https://github.com/microsoft/vscode-black-formatter/blob/458ed8f03f03c6e021361b7dcf4a8c7ab7c3d5fb/src/common/settings.ts#L64-L71

fixes: #448 

## Test Plan

Note that you'll need to launch the VS Code from the shell so that the VS Code process can see the variables which are present in an activate virtual environment.

```console
$ echo $VIRTUAL_ENV
/Users/dhruv/playground/ruff/.venv

$ code --extensionDevelopmentPath=/Users/dhruv/work/astral/ruff-vscode .
```

Using the following settings:
```json
{
  "ruff.interpreter": ["${env:VIRTUAL_ENV}/bin/python"]
}
```

Logs:
```
2024-07-24 09:15:11.563 [info] Using interpreter: /Users/dhruv/playground/ruff/.venv/bin/python
2024-07-24 09:15:11.634 [info] Using the Ruff binary: /Users/dhruv/playground/ruff/.venv/bin/ruff
2024-07-24 09:15:11.640 [info] Resolved 'ruff.nativeServer: auto' to use the native server
2024-07-24 09:15:11.642 [info] Found Ruff 0.5.4 at /Users/dhruv/playground/ruff/.venv/bin/ruff
2024-07-24 09:15:11.642 [info] Server run command: /Users/dhruv/playground/ruff/.venv/bin/ruff server
2024-07-24 09:15:11.642 [info] Server: Start requested.
```
