### PR TITLE
Avoid awaiting VS Code popup notifications

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,7 +181,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       };
 
       await lsClient.sendRequest(ExecuteCommandRequest.type, params).then(undefined, async () => {
-        await vscode.window.showErrorMessage(
+        vscode.window.showErrorMessage(
           "Failed to apply Ruff fixes to the document. Please consider opening an issue with steps to reproduce.",
         );
       });
@@ -206,7 +206,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       };
 
       await lsClient.sendRequest(ExecuteCommandRequest.type, params).then(undefined, async () => {
-        await vscode.window.showErrorMessage(
+        vscode.window.showErrorMessage(
           "Failed to apply Ruff formatting to the document. Please consider opening an issue with steps to reproduce.",
         );
       });
@@ -231,7 +231,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       };
 
       await lsClient.sendRequest(ExecuteCommandRequest.type, params).then(undefined, async () => {
-        await vscode.window.showErrorMessage(
+        vscode.window.showErrorMessage(
           `Failed to apply Ruff fixes to the document. Please consider opening an issue at ${issueTracker} with steps to reproduce.`,
         );
       });
@@ -247,7 +247,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       };
 
       await lsClient.sendRequest(ExecuteCommandRequest.type, params).then(undefined, async () => {
-        await vscode.window.showErrorMessage("Failed to print debug information.");
+        vscode.window.showErrorMessage("Failed to print debug information.");
       });
     }),
     registerLanguageStatusItem(serverId, serverName, `${serverId}.showLogs`),


### PR DESCRIPTION
## Summary

This PR fixes a bug to avoid awaiting the VS Code popup notifications.

### How to reproduce this?

For posterity, this is how to reproduce this bug:
1. Keep the extension setting to only contain:
```json
{
	"ruff.nativeServer": true
}
```
2. Add the following additional setting which is incompatible with the native server:
```json
{
	"ruff.nativeServer": true,
	"ruff.format.args": ["--line-length=10"]
}
```
3. Saving the new settings will trigger a restart and a notification will popup which warns you about this incompatible setting (**Do NOT dismiss the notification window**)
4. Remove the `ruff.format.args` and save the settings which should then trigger a restart again

But, the restart triggered by (3) never completed because the notification was awaited and the user never dismissed it. This is where the extension hangs.

### Solution

I've updated all `vscode.window.show(Error|Warning)Message` calls to not be awaited and instead use the callback mechanism if there's a need to respond to user's selection.

## Test Plan

Follow the same steps as above and make sure that the restart happens.

https://github.com/user-attachments/assets/28781673-9472-4ad7-9da8-d15302877307


