### PR TITLE
Separate server start / stop logic

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -396,21 +396,14 @@ async function createServer(
 }
 
 let _disposables: Disposable[] = [];
-export async function restartServer(
+
+export async function startServer(
   projectRoot: vscode.WorkspaceFolder,
   workspaceSettings: ISettings,
   serverId: string,
   serverName: string,
   outputChannel: LogOutputChannel,
-  lsClient?: LanguageClient,
 ): Promise<LanguageClient | undefined> {
-  if (lsClient) {
-    traceInfo(`Server: Stop requested`);
-    await lsClient.stop();
-    _disposables.forEach((d) => d.dispose());
-    _disposables = [];
-  }
-
   updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
   const extensionSettings = await getExtensionSettings(serverId);
@@ -453,4 +446,11 @@ export async function restartServer(
   }
 
   return newLSClient;
+}
+
+export async function stopServer(lsClient: LanguageClient): Promise<void> {
+  traceInfo(`Server: Stop requested`);
+  await lsClient.stop();
+  _disposables.forEach((d) => d.dispose());
+  _disposables = [];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
   onDidChangePythonInterpreter,
   resolveInterpreter,
 } from "./common/python";
-import { restartServer } from "./common/server";
+import { startServer, stopServer } from "./common/server";
 import {
   checkIfConfigurationChanged,
   getInterpreterFromSetting,
@@ -89,6 +89,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     restartInProgress = true;
 
     try {
+      if (lsClient) {
+        await stopServer(lsClient);
+      }
+
       const projectRoot = await getProjectRoot();
       const workspaceSettings = await getWorkspaceSettings(serverId, projectRoot);
 
@@ -124,13 +128,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }
       }
 
-      lsClient = await restartServer(
+      lsClient = await startServer(
         projectRoot,
         workspaceSettings,
         serverId,
         serverName,
         outputChannel,
-        lsClient,
       );
     } finally {
       // Ensure that we reset the flag in case of an error, early return, or success.
@@ -268,6 +271,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 export async function deactivate(): Promise<void> {
   if (lsClient) {
-    await lsClient.stop();
+    await stopServer(lsClient);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #558

This PR separates the server start and stop logic.

This is required because the extension could skip starting the server in the following cases:
1. No Python interpreter is selected
2. Python extension is unable to resolve the environment for the given Python interpreter
3. Python version is incompatible

So, if the extension was already running and the settings were updated to hit any one of the above cases, the server would still be running (not ideal).

## Test Plan

Here, the diagnostics should disappear because the server stopped first before checking for the interpreter.

For (1),

I'd need to uninstall all Python versions for me to reproduce this so I'm skipping this scenario assuming that (2) and (3) is sufficient.

For (2),

https://github.com/user-attachments/assets/124ab434-c082-4e67-a606-24040d8f04a8

For (3),

https://github.com/user-attachments/assets/2300ee88-01be-45be-9c03-ae2ff4aeda78


