### PR TITLE
Add support for Windows `.cmd` and `.bat` files

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -48,17 +48,14 @@ export type IInitializationOptions = {
 /**
  * Check if shell mode is required for execFile.
  * Note: This is only the case for Windows OS when using .cmd instead of .exe extension to start the interpreter.
- * @param file
- * @returns
  */
 export function execFileShellModeRequired(file: string) {
-  return platform() === "win32" && file.toLowerCase().endsWith(".cmd");
+  const lfile = file.toLowerCase();
+  return platform() === "win32" && (lfile.endsWith(".cmd") || lfile.endsWith(".bat"));
 }
 
 /**
  * Quote given file if shell mode is required
- * @param file
- * @returns
  */
 function quoteFilename(file: string) {
   if (execFileShellModeRequired(file)) {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -46,41 +46,30 @@ export type IInitializationOptions = {
 };
 
 /**
- * Check if shell mode is required for execFile.
- * Note: This is only the case for Windows OS when using .cmd instead of .exe extension to start the interpreter.
+ * Check if shell mode is required for `execFile`.
+ *
+ * The conditions are:
+ * - Windows OS
+ * - File extension is `.cmd` or `.bat`
  */
 export function execFileShellModeRequired(file: string) {
-  const lfile = file.toLowerCase();
-  return platform() === "win32" && (lfile.endsWith(".cmd") || lfile.endsWith(".bat"));
-}
-
-/**
- * Quote given file if shell mode is required
- */
-function quoteFilename(file: string) {
-  if (execFileShellModeRequired(file)) {
-    return `"${file}"`;
-  }
-  return file;
+  file = file.toLowerCase();
+  return platform() === "win32" && (file.endsWith(".cmd") || file.endsWith(".bat"));
 }
 
 /**
  * Function to execute a command and return the stdout.
  */
 function executeFile(file: string, args: string[] = []): Promise<string> {
+  const shell = execFileShellModeRequired(file);
   return new Promise((resolve, reject) => {
-    execFile(
-      quoteFilename(file),
-      args,
-      { shell: execFileShellModeRequired(file) },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(stderr || error.message));
-        } else {
-          resolve(stdout);
-        }
-      },
-    );
+    execFile(shell ? `"${file}"` : file, args, { shell }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr || error.message));
+      } else {
+        resolve(stdout);
+      }
+    });
   });
 }
 

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -51,7 +51,7 @@ export type IInitializationOptions = {
  * @param file
  * @returns
  */
-function shellModeRequired(file: string) {
+export function execFileShellModeRequired(file: string) {
   return platform() === "win32" && file.toLowerCase().endsWith(".cmd");
 }
 
@@ -61,7 +61,7 @@ function shellModeRequired(file: string) {
  * @returns
  */
 function quoteFilename(file: string) {
-  if (shellModeRequired(file)) {
+  if (execFileShellModeRequired(file)) {
     return `"${file}"`;
   }
   return file;
@@ -75,7 +75,7 @@ function executeFile(file: string, args: string[] = []): Promise<string> {
     execFile(
       quoteFilename(file),
       args,
-      { shell: shellModeRequired(file) },
+      { shell: execFileShellModeRequired(file) },
       (error, stdout, stderr) => {
         if (error) {
           reject(new Error(stderr || error.message));

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import { platform } from "os";
 
 const EXTENSION_ID = "charliermarsh.ruff";
 
@@ -25,4 +26,8 @@ export const getDocumentPath = (p: string) => {
 
 export const getDocumentUri = (p: string) => {
   return vscode.Uri.file(getDocumentPath(p));
+};
+
+export const isWindows = () => {
+  return platform() === "win32";
 };

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,0 +1,23 @@
+import * as assert from "assert";
+import { execFileShellModeRequired } from "../common/server";
+import { isWindows } from "./helper";
+
+suite("Utils tests", () => {
+  test("Check execFile shell mode", () => {
+    assert.strictEqual(
+      execFileShellModeRequired("/use/random/python"),
+      false,
+      "Shell mode should not be required for unix paths",
+    );
+    assert.strictEqual(
+      execFileShellModeRequired("C:\\random\\python.exe"),
+      false,
+      "Shell mode should not be required for .exe files",
+    );
+    assert.strictEqual(
+      execFileShellModeRequired("C:\\random\\python.cmd"),
+      isWindows() ? true : false,
+      "Shell mode should be required for .cmd files",
+    );
+  });
+});

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -19,5 +19,10 @@ suite("Utils tests", () => {
       isWindows() ? true : false,
       "Shell mode should be required for .cmd files",
     );
+    assert.strictEqual(
+      execFileShellModeRequired("C:\\random\\python.bat"),
+      isWindows() ? true : false,
+      "Shell mode should be required for .bat files",
+    );
   });
 });

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -16,12 +16,12 @@ suite("Utils tests", () => {
     );
     assert.strictEqual(
       execFileShellModeRequired("C:\\random\\python.cmd"),
-      isWindows() ? true : false,
+      isWindows(),
       "Shell mode should be required for .cmd files",
     );
     assert.strictEqual(
       execFileShellModeRequired("C:\\random\\python.bat"),
-      isWindows() ? true : false,
+      isWindows(),
       "Shell mode should be required for .bat files",
     );
   });


### PR DESCRIPTION
## Summary

I use ruff for our embedded python interpreter. This interpreter needs to be bootstrapped (env-vars) before be able to get called (technical limit of the environment itself).
This is usually done with `.cmd` file (the modern version of `.bat`) on windows which is kind of similar to `.sh` on linux.
`.cmd`  files are often use on Windows, even vscode itself use it to start vscode on windows.

Today I noticed that I get a crash when using the `.cmd` interpreter path.

It seems that node require shell mode (in windows calling `cmd.exe` as the shell) to be able to call `.cmd` files correctly.
I needed to quote the input filename as well to avoid whitespace issues which looks like a bug in node itself.

With that PR I got no crashes anymore when the extension try to run ruff 😄 .

Note: The shell mode only get activated when the platform is windows and the file extension is `.cmd`, so users with regular executables should not be affected at all.

## Test Plan

Manual testing it locally works great and as expected.

I added a utils-test to check the require shell mode flag.

The PR is related to the changes of #539
