### PR TITLE
Use "application" scope for global only settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,13 +321,13 @@
             "debug",
             "trace"
           ],
-          "scope": "window",
+          "scope": "application",
           "type": "string"
         },
         "ruff.logFile": {
           "default": null,
           "markdownDescription": "Path to the log file for the language server.\n\n**This setting is used only by the native server.**",
-          "scope": "window",
+          "scope": "application",
           "type": "string"
         },
         "ruff.trace.server": {


### PR DESCRIPTION
## Summary

These two settings are only used from the global scope but can be defined at the workspace level. This PR updates the schema so that it's only visible in the "User" settings and not in the "Workspace" settings.

As seen in Ruff server implementation:

https://github.com/astral-sh/ruff/blob/a99832088a31b65f79e578e3131756cfdc0afb0d/crates/ruff_server/src/server.rs#L87-L95

And, we also don't have support for configuring the tracing setup for individual workspaces so it doesn't make sense either.

### Reference

From https://code.visualstudio.com/api/references/contribution-points#contributes.configuration:

* `application` - Settings that apply to all instances of VS Code and can only be configured in user settings.
* `window` - Windows (instance) specific settings which can be configured in user, workspace, or remote settings.

## Test Plan

https://github.com/user-attachments/assets/2e6409c2-5ead-4878-9061-8d0fcc8ce45e


