### PR TITLE
Set status to 'not-busy' when server startup is complete

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -441,6 +441,7 @@ export async function startServer(
   traceInfo(`Server: Start requested.`);
   try {
     await newLSClient.start();
+    updateStatus(undefined, LanguageStatusSeverity.Information, false);
   } catch (ex) {
     updateStatus(l10n.t("Server failed to start."), LanguageStatusSeverity.Error);
     traceError(`Server: Start failed: ${ex}`);

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -439,14 +439,6 @@ export async function startServer(
     },
   );
   traceInfo(`Server: Start requested.`);
-  try {
-    await newLSClient.start();
-    updateStatus(undefined, LanguageStatusSeverity.Information, false);
-  } catch (ex) {
-    updateStatus(l10n.t("Server failed to start."), LanguageStatusSeverity.Error);
-    traceError(`Server: Start failed: ${ex}`);
-    return undefined;
-  }
 
   _disposables.push(
     newLSClient.onDidChangeState((e) => {
@@ -478,12 +470,25 @@ export async function startServer(
     }),
   );
 
+  try {
+    await newLSClient.start();
+  } catch (ex) {
+    updateStatus(l10n.t("Server failed to start."), LanguageStatusSeverity.Error);
+    traceError(`Server: Start failed: ${ex}`);
+    dispose();
+    return undefined;
+  }
+
   return newLSClient;
 }
 
 export async function stopServer(lsClient: LanguageClient): Promise<void> {
   traceInfo(`Server: Stop requested`);
   await lsClient.stop();
+  dispose();
+}
+
+function dispose(): void {
   _disposables.forEach((d) => d.dispose());
   _disposables = [];
 }


### PR DESCRIPTION
## Summary

Ensures that the extension calls `updateStatus` with `busy=false` when the server startup is complete. 

This is now necessary after https://github.com/astral-sh/ruff-vscode/pull/600 correctly added an `updateStatus` call with `busy=true` before the server starts.

Fixes https://github.com/astral-sh/ruff-vscode/issues/605

## Test Plan

I ran the extension and verified that the busy indicator no longer spins forever.
