### PR TITLE
Separate publish steps for Code Marketplace and OpenVSX

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,8 +166,8 @@ jobs:
           path: ./dist
 
   # Phase 3: Publish the built extension to the Marketplace.
-  publish:
-    name: "Publish"
+  publish-code-marketplace:
+    name: "Publish (Code Marketplace)"
     needs: ["build"]
     runs-on: ubuntu-latest
     steps:
@@ -230,6 +230,63 @@ jobs:
       - name: Publish Extension (Code Marketplace, nightly)
         if: "!startsWith(github.ref, 'refs/tags/')"
         run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ruff-*.vsix --pre-release
+
+  publish-openvsx:
+    name: "Publish (OpenVSX)"
+    needs: ["build"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+
+      # Download all built artifacts.
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-aarch64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-unknown-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-aarch64-unknown-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-arm-unknown-linux-gnueabihf
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-pc-windows-msvc
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-aarch64-pc-windows-msvc
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-x86_64-unknown-linux-musl
+          path: dist
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist-aarch64-unknown-linux-musl
+          path: dist
+      - run: ls -al ./dist
+
+      # Install Node dependencies.
+      - run: npm ci
 
       # Publish to OpenVSX.
       - name: Publish Extension (OpenVSX, release)


### PR DESCRIPTION
## Summary

Publishing the extension to the OpenVSX registry fails a lot of times and there's no way to re-run just the publish step for the OpenVSX in GitHub Actions, we can only re-run the entire workflow. This PR separates the publish step into two where (1) would publish to Code Marketplace and (2) would publish to OpenVSX registry. This means that if we fail to publish to one of the registry, we could still re-run it.

### Limitation

Sometimes it does happen that only some of the artifacts are published and not all of them in which case re-running won't solve this issue. I don't really have a good solution here.
