### PR TITLE
Use extension context for output window disposable

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -416,6 +416,7 @@ async function createServer(
 let _disposables: Disposable[] = [];
 
 export async function startServer(
+  context: vscode.ExtensionContext,
   projectRoot: vscode.WorkspaceFolder,
   workspaceSettings: ISettings,
   serverId: string,
@@ -425,11 +426,13 @@ export async function startServer(
 
   // Create output channels for the server and trace logs
   const outputChannel = vscode.window.createOutputChannel(`${serverName} Language Server`);
-  _disposables.push(outputChannel);
+  context.subscriptions.push(outputChannel);
   const traceOutputChannel = new LazyOutputChannel(`${serverName} Language Server Trace`);
-  _disposables.push(traceOutputChannel);
+  context.subscriptions.push(traceOutputChannel);
   // And, a command to show the server logs
-  _disposables.push(registerCommand(`${serverId}.showServerLogs`, () => outputChannel.show()));
+  context.subscriptions.push(
+    registerCommand(`${serverId}.showServerLogs`, () => outputChannel.show()),
+  );
 
   const extensionSettings = await getExtensionSettings(serverId);
   const globalSettings = await getGlobalSettings(serverId);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         }
       }
 
-      lsClient = await startServer(projectRoot, workspaceSettings, serverId, serverName);
+      lsClient = await startServer(context, projectRoot, workspaceSettings, serverId, serverName);
     } finally {
       // Ensure that we reset the flag in case of an error, early return, or success.
       restartInProgress = false;


### PR DESCRIPTION
## Summary

I noticed this in https://github.com/astral-sh/ruff-vscode/pull/585 that we would not be able to look at the error message when the server crashes because the output window got disposed. This is because the disposable is tied up with stopping the server. This PR updates that to include the disposable to the extension context so that it gets disposed only when the extension is deactivated.

## Test Plan

Run the scenario from https://github.com/astral-sh/ruff-vscode/pull/585 to make sure that the "Ruff Language Server" window is not disposed in case the server crashed.
