### PR TITLE
Add deprecation warning for `ruff-lsp` specific settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,12 @@ Finally, to use a common Ruff configuration across all projects, consider creati
 
 #### Python-based language server (`ruff-lsp`)
 
+> [!WARNING]
+>
+> [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) is deprecated and will be
+> removed in a future release. Please switch to the Rust-based language server
+> (`ruff server`) instead.
+
 If you're using the default Python-based language server, you can use the `ruff.lint.args` and
 `ruff.format.args` settings in `settings.json` to pass command-line arguments to Ruff.
 

--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
             "Automatically select between the native language server and [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) based on the following conditions:\n1. If the Ruff version is >= `0.5.3`, use the native language server unless any deprecated settings are detected. In that case, show a warning and use [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) instead.\n2. If the Ruff version is < `0.5.3`, use [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). A warning will be displayed if settings specific to the native server are detected.",
             "Same as `on`.",
             "Same as `off`."
-          ]
+          ],
+          "markdownDeprecationMessage": "**Deprecated**: This setting has been deprecated with the deprecation of [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). It was mainly used to provide a way to switch between the native language server and [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) during the transition period. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration) for more information.",
+          "deprecationMessage": "Deprecated: This setting has been deprecated with the deprecation of ruff-lsp. It was mainly used to provide a way to switch between the native language server and ruff-lsp during the transition period."
         },
         "ruff.configuration": {
           "default": null,
@@ -120,6 +122,8 @@
         "ruff.lint.args": {
           "default": [],
           "markdownDescription": "Additional command-line arguments to pass to `ruff check`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.\n\n**This setting is not supported by the native server.**",
+          "markdownDeprecationMessage": "**Deprecated**: This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is deprecated in favor of the native language server. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration) for more information.",
+          "deprecationMessage": "Deprecated: This setting is only used by ruff-lsp which is deprecated in favor of the native language server.",
           "items": {
             "type": "string"
           },
@@ -194,6 +198,8 @@
             "Run Ruff on every keystroke.",
             "Run Ruff on save."
           ],
+          "markdownDeprecationMessage": "**Deprecated**: This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is deprecated in favor of the native language server. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration) for more information.",
+          "deprecationMessage": "Deprecated: This setting is only used by ruff-lsp which is deprecated in favor of the native language server.",
           "scope": "window",
           "type": "string"
         },
@@ -206,6 +212,8 @@
         "ruff.format.args": {
           "default": [],
           "markdownDescription": "Additional command-line arguments to pass to `ruff format`, e.g., `\"args\": [\"--config=/path/to/pyproject.toml\"]`. Supports a subset of Ruff's command-line arguments, ignoring those that are required to operate the LSP, like `--force-exclude` and `--verbose`.\n\n**This setting is not supported by the native server.**",
+          "markdownDeprecationMessage": "**Deprecated**: This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is deprecated in favor of the native language server. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration) for more information.",
+          "deprecationMessage": "Deprecated: This setting is only used by ruff-lsp which is deprecated in favor of the native language server.",
           "items": {
             "type": "string"
           },
@@ -243,7 +251,7 @@
         },
         "ruff.interpreter": {
           "default": [],
-          "markdownDescription": "Path to a Python interpreter to use to run the LSP server.",
+          "markdownDescription": "Path to a Python interpreter to use to find the `ruff` executable.",
           "scope": "resource",
           "items": {
             "type": "string"
@@ -309,6 +317,8 @@
         "ruff.ignoreStandardLibrary": {
           "default": true,
           "markdownDescription": "Whether to ignore files that are inferred to be part of the Python standard library.",
+          "markdownDeprecationMessage": "**Deprecated**: This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is deprecated in favor of the native language server. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration) for more information.",
+          "deprecationMessage": "Deprecated: This setting is only used by ruff-lsp which is deprecated in favor of the native language server.",
           "scope": "window",
           "type": "boolean"
         },
@@ -344,6 +354,8 @@
         "ruff.showNotifications": {
           "default": "off",
           "markdownDescription": "Controls when notifications are shown by this extension.",
+          "markdownDeprecationMessage": "**Deprecated**: This setting is only used by [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) which is deprecated in favor of the native language server. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration) for more information.",
+          "deprecationMessage": "Deprecated: This setting is only used by ruff-lsp which is deprecated in favor of the native language server.",
           "enum": [
             "off",
             "onError",


### PR DESCRIPTION
## Summary

This PR adds the deprecation message to `ruff-lsp` specific settings and update the README section with a [warning message](https://github.com/astral-sh/ruff-vscode/blob/dhruv/deprecate/README.md#python-based-language-server-ruff-lsp).

There doesn't seem to be any way to show this to the user as the settings are now not visible in the settings UI although they're visible in the JSON viewer:

<img width="1097" alt="Screenshot 2025-02-03 at 12 02 50 PM" src="https://github.com/user-attachments/assets/b7406bdd-eafe-4a7f-9897-27246d0064b4" />

But, it's not visible in the hover window of the settings:

<img width="947" alt="Screenshot 2025-02-03 at 12 04 05 PM" src="https://github.com/user-attachments/assets/5706e10e-9c47-4830-b9bf-1df14745c2d6" />

### Deprecation warning

Additionally, the extension will provide a deprecation warning when Ruff version if < 0.3.5. For >= 0.3.5, `ruff-lsp` will provide the warning (https://github.com/astral-sh/ruff-lsp/pull/520).

Preview of this warning:
 
<img width="2184" alt="Screenshot 2025-02-06 at 5 30 27 PM" src="https://github.com/user-attachments/assets/54edd643-fcff-43a5-8680-5bf4ae6b493c" />

