### PR TITLE
Undeprecate `ruff.nativeServer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,9 +98,7 @@
             "Automatically select between the native language server and [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) based on the following conditions:\n1. If the Ruff version is >= `0.5.3`, use the native language server unless any deprecated settings are detected. In that case, show a warning and use [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) instead.\n2. If the Ruff version is < `0.5.3`, use [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). A warning will be displayed if settings specific to the native server are detected.",
             "Same as `on`.",
             "Same as `off`."
-          ],
-          "markdownDeprecationMessage": "**Deprecated**: This setting has been deprecated with the deprecation of [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). It was mainly used to provide a way to switch between the native language server and [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp) during the transition period. Refer to the [migration guide](https://docs.astral.sh/ruff/editors/migration) for more information.",
-          "deprecationMessage": "Deprecated: This setting has been deprecated with the deprecation of ruff-lsp. It was mainly used to provide a way to switch between the native language server and ruff-lsp during the transition period."
+          ]
         },
         "ruff.configuration": {
           "default": null,


### PR DESCRIPTION
Based on feedback in https://github.com/astral-sh/ruff/discussions/15991#discussioncomment-12095853, https://github.com/astral-sh/ruff/discussions/15991#discussioncomment-12099643.