### PR TITLE
Warn against certain values in `notebook.codeActionsOnSave`

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -365,7 +365,7 @@ export function checkNotebookCodeActionsOnSave(serverId: string) {
           genericCodeActions,
         )}. Consider using ${JSON.stringify(
           genericCodeActions.map((action) => `notebook.${action}`),
-        )} instead.`,
+        )} instead. For more information, refer to [this FAQ section](https://docs.astral.sh/ruff/faq/#source-code-actions-in-notebooks).`,
       );
     }
 
@@ -374,7 +374,7 @@ export function checkNotebookCodeActionsOnSave(serverId: string) {
         ruffCodeActions,
       )}. Please use ${JSON.stringify(
         ruffCodeActions.map((action) => `notebook.${action}`),
-      )} instead.`;
+      )} instead. For more information, refer to [this FAQ section](https://docs.astral.sh/ruff/faq/#source-code-actions-in-notebooks).`;
 
       logger.warn(message);
       // Only show a warning if there are Ruff-specific code actions configured.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import {
   getInterpreterFromSetting,
   getWorkspaceSettings,
   ISettings,
+  checkNotebookCodeActionsOnSave,
 } from "./common/settings";
 import { loadServerDefaults } from "./common/setup";
 import { registerLanguageStatusItem, updateStatus } from "./common/status";
@@ -264,6 +265,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     registerLanguageStatusItem(serverId, serverName, `${serverId}.showLogs`),
   );
+
+  checkNotebookCodeActionsOnSave(serverId);
 
   setImmediate(async () => {
     if (vscode.workspace.isTrusted) {


### PR DESCRIPTION
## Summary

This PR adds a check for `notebook.codeActionsOnSave` to do the following:
* For `source.fixAll` and `source.organizeImports`, log at info level
* For `source.fixAll.ruff` and `source.organizeImports.ruff`, log at warn level and provide a warning message to use `notebook.` prefixed code actions instead

## Test Plan

Using the following settings:
```json
{
  "notebook.codeActionsOnSave": {
    "source.fixAll": "explicit",
    "source.organizeImports": "explicit",
    "source.organizeImports.ruff": "explicit",
    "source.fixAll.ruff": "explicit"
  }
}
```

Logs:

```
2025-02-17 20:06:34.796 [info] The following code actions in 'notebook.codeActionsOnSave' could lead to unexpected behavior: ["source.fixAll","source.organizeImports"]. Consider using ["notebook.source.fixAll","notebook.source.organizeImports"] instead. For more information, refer to [this FAQ section](https://docs.astral.sh/ruff/faq/#source-code-actions-in-notebooks).
2025-02-17 20:06:34.796 [warning] The following code actions in 'notebook.codeActionsOnSave' will lead to unexpected behavior: ["source.organizeImports.ruff","source.fixAll.ruff"]. Please use ["notebook.source.organizeImports.ruff","notebook.source.fixAll.ruff"] instead. For more information, refer to [this FAQ section](https://docs.astral.sh/ruff/faq/#source-code-actions-in-notebooks).
```

Notification preview:

<img width="475" alt="Screenshot 2025-02-17 at 8 06 54 PM" src="https://github.com/user-attachments/assets/fbcb15e4-cb62-4a22-bd89-1a4d38798369" />