### PR TITLE
Allow arbitrary config keys in `ruff.configuration`

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
             },
             {
               "type": "object",
-              "markdownDescription": "Set of TOML `<KEY> = <VALUE>` pairs (such as you might find in a `ruff.toml` configuration file) overriding configuration from the filesystem."
+              "markdownDescription": "Inline JSON configuration for Ruff settings (e.g., `{ \"line-length\": 100 }`). *Added in Ruff 0.9.8.*"
             }
           ]
         },

--- a/package.json
+++ b/package.json
@@ -102,9 +102,22 @@
         },
         "ruff.configuration": {
           "default": null,
-          "markdownDescription": "Path to a `ruff.toml` or `pyproject.toml` file to use for configuration. By default, Ruff will discover configuration for each project from the filesystem, mirroring the behavior of the Ruff CLI.\n\n**This setting is used only by the native server.**",
+          "markdownDescription": "Configuration overrides for Ruff. See [the documentation](https://docs.astral.sh/ruff/editors/settings/#configuration) for more details.\n\n**This setting is used only by the native server.**",
           "scope": "window",
-          "type": "string"
+          "type": [
+            "string",
+            "object"
+          ],
+          "oneOf": [
+            {
+              "type": "string",
+              "markdownDescription": "Path to a `ruff.toml` or `pyproject.toml` file to use for configuration."
+            },
+            {
+              "type": "object",
+              "markdownDescription": "Set of TOML `<KEY> = <VALUE>` pairs (such as you might find in a `ruff.toml` configuration file) overriding configuration from the filesystem."
+            }
+          ]
         },
         "ruff.args": {
           "default": [],

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -21,6 +21,7 @@ import {
 import { logger } from "./logger";
 import { getDebuggerPath } from "./python";
 import {
+  checkInlineConfigSupport,
   getExtensionSettings,
   getGlobalSettings,
   getUserSetLegacyServerSettings,
@@ -189,6 +190,8 @@ async function createNativeServer(
       vscode.window.showErrorMessage(message);
       return Promise.reject();
     }
+
+    checkInlineConfigSupport(ruffVersion, serverId);
   }
 
   let ruffServerArgs: string[];

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -50,7 +50,7 @@ export interface ISettings {
   path: string[];
   ignoreStandardLibrary: boolean;
   interpreter: string[];
-  configuration: string | null;
+  configuration: string | object | null;
   importStrategy: ImportStrategy;
   codeAction: CodeAction;
   enable: boolean;
@@ -135,8 +135,8 @@ export async function getWorkspaceSettings(
     interpreter = resolveVariables(interpreter, workspace);
   }
 
-  let configuration = config.get<string>("configuration") ?? null;
-  if (configuration !== null) {
+  let configuration = config.get<string | object>("configuration") ?? null;
+  if (configuration !== null && typeof configuration === "string") {
     configuration = resolveVariables(configuration, workspace);
   }
 
@@ -199,7 +199,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     path: getGlobalValue<string[]>(config, "path", []),
     ignoreStandardLibrary: getGlobalValue<boolean>(config, "ignoreStandardLibrary", true),
     interpreter: [],
-    configuration: getGlobalValue<string | null>(config, "configuration", null),
+    configuration: getGlobalValue<string | object | null>(config, "configuration", null),
     importStrategy: getGlobalValue<ImportStrategy>(config, "importStrategy", "fromEnvironment"),
     codeAction: getGlobalValue<CodeAction>(config, "codeAction", {}),
     lint: {

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -58,3 +58,15 @@ export const NATIVE_SERVER_STABLE_VERSION: VersionInfo = { major: 0, minor: 5, p
 export function supportsStableNativeServer(version: VersionInfo): boolean {
   return versionGte(version, NATIVE_SERVER_STABLE_VERSION);
 }
+
+/**
+ * The minimum version of the Ruff executable that supports inline configuration.
+ */
+export const INLINE_CONFIGURATION_VERSION: VersionInfo = { major: 0, minor: 9, patch: 8 };
+
+/**
+ * Check if the given version of the Ruff executable supports inline configuration.
+ */
+export function supportsInlineConfiguration(version: VersionInfo): boolean {
+  return versionGte(version, INLINE_CONFIGURATION_VERSION);
+}


### PR DESCRIPTION
## Summary

Closes: #6 

This PR adds support for https://github.com/astral-sh/ruff/pull/16296 for the VS Code extension by allowing any arbitrary object in `ruff.configuration`

Additionally, it will provide a warning message to the user if they're using inline configuration but the Ruff version does not support it.

It has one disadvantage that the user will see two popups where the error one is coming from the server because it cannot deserialize the options. We could not show the warning popup if this is too much. I'm worried that it might go unnoticed because the "Show Logs" in the below popup will open the server logs while the message would be in the client logs.

<img width="491" alt="Screenshot 2025-02-25 at 1 24 15 PM" src="https://github.com/user-attachments/assets/8bafbd69-f8fa-4604-8ab3-1f6efa745045" />

We'll still log it on the console (client log channel):
```
2025-02-25 13:24:10.067 [warning] Inline configuration support was added in Ruff 0.9.8 (current version is 0.9.7). Please update your Ruff version to use this feature.
```

I haven't provided more details in the warning message based on the assumption that if the user is using inline configuration then they're aware of it but it's just that the Ruff version is too old.

## Test Plan

Refer to the test plan in https://github.com/astral-sh/ruff/pull/16296
