### PR TITLE
Make it easier for Windows users to test Red Knot

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -174,8 +174,10 @@ async function createNativeServer(
   const { path: ruffBinaryPath, version: ruffVersion } = ruffExecutable;
 
   logger.info(`Found Ruff ${versionToString(ruffVersion)} at ${ruffBinaryPath}`);
+  
+  const isRedKnot = ruffBinaryPath.endsWith('red_knot') || ruffBinaryPath.endsWith('red_knot.exe');
 
-  if (!ruffBinaryPath.endsWith("red_knot") && !ruffBinaryPath.endsWith("red_knot.exe")) {
+  if (!isRedKnot) {
     if (!supportsNativeServer(ruffVersion)) {
       const message =
         `Native server requires Ruff ${versionToString(
@@ -192,7 +194,7 @@ async function createNativeServer(
   }
 
   let ruffServerArgs: string[];
-  if (ruffBinaryPath.endsWith("red_knot") || ruffBinaryPath.endsWith("red_knot.exe")) {
+  if (isRedKnot) {
     ruffServerArgs = [RUFF_SERVER_SUBCOMMAND];
   } else if (supportsStableNativeServer(ruffVersion)) {
     ruffServerArgs = [RUFF_SERVER_SUBCOMMAND];

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -174,8 +174,8 @@ async function createNativeServer(
   const { path: ruffBinaryPath, version: ruffVersion } = ruffExecutable;
 
   logger.info(`Found Ruff ${versionToString(ruffVersion)} at ${ruffBinaryPath}`);
-  
-  const isRedKnot = ruffBinaryPath.endsWith('red_knot') || ruffBinaryPath.endsWith('red_knot.exe');
+
+  const isRedKnot = ruffBinaryPath.endsWith("red_knot") || ruffBinaryPath.endsWith("red_knot.exe");
 
   if (!isRedKnot) {
     if (!supportsNativeServer(ruffVersion)) {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -175,7 +175,7 @@ async function createNativeServer(
 
   logger.info(`Found Ruff ${versionToString(ruffVersion)} at ${ruffBinaryPath}`);
 
-  if (!ruffBinaryPath.endsWith("red_knot")) {
+  if (!ruffBinaryPath.endsWith("red_knot") && !ruffBinaryPath.endsWith("red_knot.exe")) {
     if (!supportsNativeServer(ruffVersion)) {
       const message =
         `Native server requires Ruff ${versionToString(
@@ -192,7 +192,7 @@ async function createNativeServer(
   }
 
   let ruffServerArgs: string[];
-  if (ruffBinaryPath.endsWith("red_knot")) {
+  if (ruffBinaryPath.endsWith("red_knot") || ruffBinaryPath.endsWith("red_knot.exe")) {
     ruffServerArgs = [RUFF_SERVER_SUBCOMMAND];
   } else if (supportsStableNativeServer(ruffVersion)) {
     ruffServerArgs = [RUFF_SERVER_SUBCOMMAND];


### PR DESCRIPTION
## Summary

The extension now also recognizes `red_knot.exe` as a Red Knot affix.

## Test Plan

None.
