### PR TITLE
Avoid inline config warning when value is `null`

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -345,8 +345,9 @@ export function checkInlineConfigSupport(ruffVersion: VersionInfo, serverId: str
   }
 
   getWorkspaceFolders().forEach((workspace) => {
-    const config = getConfiguration(serverId, workspace.uri).get<string | object>("configuration");
-    if (typeof config === "object") {
+    const config =
+      getConfiguration(serverId, workspace.uri).get<string | object>("configuration") ?? null;
+    if (config !== null && typeof config === "object") {
       const message = `Inline configuration support was added in Ruff ${versionToString(
         INLINE_CONFIGURATION_VERSION,
       )} (current version is ${versionToString(


### PR DESCRIPTION
## Summary

fixup from #702 

## Test Plan

Verified that `null` (not setting `ruff.configuration`) doesn't give me the warning.
