### PR TITLE
Bump Ubuntu version in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,14 +51,14 @@ jobs:
           - os: windows-latest
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
             arch: aarch64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: arm-unknown-linux-gnueabihf
             code-target: linux-armhf
             arch: armv7
@@ -68,11 +68,11 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
             code-target: darwin-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-musl
             code-target: alpine-x64
             arch: x86_64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-musl
             code-target: alpine-arm64
             arch: aarch64


### PR DESCRIPTION
## Summary

I noticed the warnings about the Ubuntu 20.04 brownout during the release today. We're actually only 10 days from the end of the brownout period and when 20.04 is fully unsupported ([ref](https://github.com/actions/runner-images/issues/11101)).

There's one additional mention of 20.04 a bit farther down in the file for the `run-on-arch` action, but that's the same with Ruff.

Possibly we could also bump all the way to 24.04 if we wanted.
