### PR TITLE
filesystemFirst by default

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -179,7 +179,7 @@ export async function getWorkspaceSettings(
     exclude: config.get<string[]>("exclude"),
     lineLength: config.get<number>("lineLength"),
     configurationPreference:
-      config.get<ConfigPreference>("configurationPreference") ?? "editorFirst",
+      config.get<ConfigPreference>("configurationPreference") ?? "filesystemFirst",
     showSyntaxErrors: config.get<boolean>("showSyntaxErrors") ?? true,
     logLevel: config.get<LogLevel>("logLevel"),
     logFile: config.get<string>("logFile"),


### PR DESCRIPTION
Workspace settings should have higher priority. User editor settings should not trump team workspace settings.

<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
