### PR TITLE
Log client settings for workspace and global

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -450,7 +450,11 @@ export async function startServer(
   updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
   const extensionSettings = await getExtensionSettings(serverId);
+  for (const settings of extensionSettings) {
+    logger.info(`Workspace settings for ${settings.cwd}: ${JSON.stringify(settings, null, 4)}`);
+  }
   const globalSettings = await getGlobalSettings(serverId);
+  logger.info(`Global settings: ${JSON.stringify(globalSettings, null, 4)}`);
 
   let newLSClient = await createServer(
     workspaceSettings,


### PR DESCRIPTION
## Summary

This PR adds both workspace and global client settings at INFO level.

Maybe this would be more useful at the server level but this could also reveal some bug on the client side code.

### Preview

```
2025-04-29 16:06:02.475 [info] Using interpreter: /Users/dhruv/work/astral/ruff-vscode/.venv/bin/python
2025-04-29 16:06:02.477 [info] Workspace settings for /Users/dhruv/playground/ruff: {
    "nativeServer": "on",
    "cwd": "/Users/dhruv/playground/ruff",
    "workspace": "file:///Users/dhruv/playground/ruff",
    "path": [
        "/Users/dhruv/work/astral/ruff/target/debug/ruff"
    ],
    "ignoreStandardLibrary": true,
    "interpreter": [
        "/Users/dhruv/work/astral/ruff-vscode/.venv/bin/python"
    ],
    "configuration": "/Users/dhruv/playground/ruff/formatter/ruff.toml",
    "importStrategy": "fromEnvironment",
    "codeAction": {
        "fixViolation": {
            "enable": true
        },
        "disableRuleComment": {
            "enable": true
        }
    },
    "lint": {
        "enable": true,
        "run": "onType",
        "args": [],
        "preview": null,
        "select": null,
        "extendSelect": null,
        "ignore": null
    },
    "format": {
        "args": [],
        "preview": null
    },
    "enable": true,
    "organizeImports": true,
    "fixAll": true,
    "showNotifications": "off",
    "exclude": null,
    "lineLength": null,
    "configurationPreference": "editorFirst",
    "showSyntaxErrors": true,
    "logLevel": "debug",
    "logFile": null
}
2025-04-29 16:06:02.478 [info] Global settings: {
    "nativeServer": "on",
    "cwd": "/",
    "workspace": "/",
    "path": [
        "/Users/dhruv/work/astral/ruff/target/debug/ruff"
    ],
    "ignoreStandardLibrary": true,
    "interpreter": [],
    "configuration": "${workspaceFolder}/formatter/ruff.toml",
    "importStrategy": "fromEnvironment",
    "codeAction": {
        "fixViolation": {
            "enable": true
        },
        "disableRuleComment": {
            "enable": true
        }
    },
    "lint": {
        "enable": true,
        "run": "onType",
        "args": []
    },
    "format": {
        "args": []
    },
    "enable": true,
    "organizeImports": true,
    "fixAll": true,
    "showNotifications": "off",
    "configurationPreference": "editorFirst",
    "showSyntaxErrors": true,
    "logLevel": "debug"
}
2025-04-29 16:06:02.478 [info] Using 'path' setting: /Users/dhruv/work/astral/ruff/target/debug/ruff
2025-04-29 16:06:02.486 [info] Found Ruff 0.11.7 at /Users/dhruv/work/astral/ruff/target/debug/ruff
2025-04-29 16:06:02.486 [info] Server run command: /Users/dhruv/work/astral/ruff/target/debug/ruff server
2025-04-29 16:06:02.486 [info] Server: Start requested.
```
