### PR TITLE
Remove unnecessary metadata from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,6 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [project]
 name = "ruff-vscode"
-version = "2025.22.0"
-description = "A Visual Studio Code extension with support for the Ruff linter."
-authors = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]
-maintainers = [{ name = "Charlie Marsh", email = "charlie.r.marsh@gmail.com" }]
 requires-python = ">=3.7"
-license = "MIT"
 dependencies = ["packaging>=23.1", "ruff-lsp==0.0.62", "ruff==0.11.2"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

This never gets built as a package; this is just used for metadata.
