### PR TITLE
Restore version field in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "ruff-vscode"
+version = "2025.24.0"
 requires-python = ">=3.7"
 dependencies = ["packaging>=23.1", "ruff-lsp==0.0.62", "ruff==0.12.0"]
 


### PR DESCRIPTION
## Summary

This reverts a small part of #750. The `version` field is used by the release script, so I think we should keep it around.

## Test Plan

I added back `2025.22.0` before running the release script, which was then updated to `2025.24.0`. That's why this is stacked on the release branch too.
