### PR TITLE
chore(ci): address CI linting issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   ci:
     strategy:
@@ -21,6 +23,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 # v6.5.0
         with:
           activate-environment: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 env:
   FETCH_DEPTH: 0
 
+permissions: {}
+
 jobs:
   # Phase 1: Generate the Build ID.
   # We have to do this ahead-of-time, and store it as a job output,
@@ -22,6 +24,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
@@ -87,6 +90,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
 
       # Install Python dependencies (including Ruff's native binary).
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -144,11 +148,15 @@ jobs:
       - name: Set Build ID (release)
         if: "startsWith(github.ref, 'refs/tags/')"
         run: |
-          python -m build.update_ext_version --build-id ${{ needs.build-id.outputs.RELEASE_BUILD_ID }} --for-publishing
+          python -m build.update_ext_version --build-id "${RELEASE_BUILD_ID}" --for-publishing
+        env:
+          RELEASE_BUILD_ID: ${{ needs.build-id.outputs.RELEASE_BUILD_ID }}
       - name: Set Build ID (nightly)
         if: "!startsWith(github.ref, 'refs/tags/')"
         run: |
-          python -m build.update_ext_version --build-id ${{ needs.build-id.outputs.NIGHTLY_BUILD_ID }} --for-publishing --pre-release
+          python -m build.update_ext_version --build-id "${NIGHTLY_BUILD_ID}" --for-publishing --pre-release
+        env:
+          NIGHTLY_BUILD_ID: ${{ needs.build-id.outputs.NIGHTLY_BUILD_ID }}
 
       # Build the extension.
       - name: Package Extension (release)
@@ -180,6 +188,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
 
       # Download all built artifacts.
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -245,6 +254,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
 
       # Download all built artifacts.
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,24 @@
+name: zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2


### PR DESCRIPTION
## Summary

This is part of my general burndown of CI linting issues.

Fixes some small permissions and template issues,
adds a zizmor workflow to catch future issues.

## Test Plan

See what happens in CI 🙂. Unless I'm missing something there should be no breaking changes here, since neither `ci.yaml` nor `release.yaml` uses any dedicated workflow permissions.