### PR TITLE
Set the shell to bash to fix environment variable expansion

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ env:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Phase 1: Generate the Build ID.
   # We have to do this ahead-of-time, and store it as a job output,
@@ -146,7 +150,6 @@ jobs:
 
       # Set the Build ID.
       - name: Set Build ID (release)
-        shell: bash
         if: "startsWith(github.ref, 'refs/tags/')"
         run: |
           python -m build.update_ext_version --build-id "${RELEASE_BUILD_ID}" --for-publishing


### PR DESCRIPTION
Windows builds for the 2025.26.0 release were failing today with an empty argument to the `--build-id` flag. I think this is because environment variable expansion works slightly differently on Windows runners:

> By default, Windows runners use PowerShell, so you would use the syntax $env:NAME.

[ref](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#defining-environment-variables-for-a-single-workflow)

Hopefully by requesting bash we can get around this. I see some `shell: bash` instances in Ruff's build-binaries workflows, so hopefully this is a reasonable fix.

See <https://github.com/astral-sh/ruff-vscode/actions/runs/17621286845/job/50067401930> for example.
