### PR TITLE
Support workspace-level `ruff.configuration`

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "ruff.configuration": {
           "default": null,
           "markdownDescription": "Configuration overrides for Ruff. See [the documentation](https://docs.astral.sh/ruff/editors/settings/#configuration) for more details.\n\n**This setting is used only by the native server.**",
-          "scope": "window",
+          "scope": "resource",
           "type": [
             "string",
             "object"


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ruff-vscode/issues/886

Change the `scope` of `ruff.configuration` to `resource` so that it can be configured per workspace root. 

This doesn't require any change in Ruff itself because we already respect that setting per workspace.

## Test Plan

I reproduced the layout from https://github.com/astral-sh/ruff-vscode/issues/886 
and tested that Ruff resolves the configuration from the closest workspace root
