### PR TITLE
Improve extension discoverability in VSCode Marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ruff",
   "displayName": "Ruff",
-  "description": "A Visual Studio Code extension with support for the Ruff linter and formatter.",
+  "description": "A Visual Studio Code extension with support for the Ruff linter and formatter for Python.",
   "version": "2025.30.0",
   "serverInfo": {
     "name": "Ruff",


### PR DESCRIPTION
Fixes #896 


## Summary

Rephrases the description to include the word "Python" so it shows up when VSCode automatically searches for python formatters:

<img width="664" height="709" alt="image" src="https://github.com/user-attachments/assets/6cd6cb02-4d74-40ed-a3b1-01125d252e38" />


## Test Plan

The test plan is to publish the extension with the new description and see if it shows up in the search. 


