### PR TITLE
Increase max allowed value for line length setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -411,7 +411,7 @@
           "default": null,
           "minimum": 1,
           "maximum": 65535,
-          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0. Ruff 0.15.12 or older used a maximum of 320.\n\n**This setting is used only by the native server.**",
+          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0. Ruff 0.15.12 or older uses a maximum of 320.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": [
             "integer",

--- a/package.json
+++ b/package.json
@@ -410,8 +410,8 @@
         "ruff.lineLength": {
           "default": null,
           "minimum": 1,
-          "maximum": 320,
-          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0 and less than or equal to 320.\n\n**This setting is used only by the native server.**",
+          "maximum": 65535,
+          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0 and less than or equal to 65535.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": [
             "integer",

--- a/package.json
+++ b/package.json
@@ -411,7 +411,7 @@
           "default": null,
           "minimum": 1,
           "maximum": 65535,
-          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0 and less than or equal to 65535.\n\n**This setting is used only by the native server.**",
+          "markdownDescription": "Set the [line length](https://docs.astral.sh/ruff/settings/#line-length) used by the formatter and linter. Must be greater than 0. Ruff 0.15.12 or older used a maximum of 320.\n\n**This setting is used only by the native server.**",
           "scope": "resource",
           "type": [
             "integer",


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Changes the VSCode config limitation to align with https://github.com/astral-sh/ruff/pull/24962

<!-- What's the purpose of the change? What does it do, and why? -->

This moved the upper UI restriction from 320 to 65535 in accordance with the changes to PR!24962

<!-- How was it tested? -->

Changes to local extensions package.json and a restart of VSCode shows the parameter is now accepted in the settings panel, and warns if beyond accordingly.