### PR TITLE
Add support for the Python Environment Extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^24.0.0",
         "@types/vscode": "1.75.0",
         "@types/which": "^3.0.4",
+        "@vscode/python-environments": "^1.0.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.4.2",
@@ -2018,6 +2019,17 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vscode/python-environments": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+      "integrity": "sha512-utsAkb9lX8jVJxTR11aFu5Z2LWNwmHp3Ki+tmNNTiHVY71gNcwgYRrnwRhdE6+DFj3sLznjvcE/dCaAgXX9ohA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.21.1",
+        "vscode": "^1.110.0"
+      }
     },
     "node_modules/@vscode/python-extension": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -493,6 +493,7 @@
     "@types/node": "^24.0.0",
     "@types/vscode": "1.75.0",
     "@types/which": "^3.0.4",
+    "@vscode/python-environments": "^1.0.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.4.2",

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -174,7 +174,7 @@ class PythonEnvironmentExtension implements EnvironmentProvider {
         const environment = event.new == null ? null : this.toEnvironmentDetails(event.new);
         const previousEnvironment = event.old == null ? null : this.toEnvironmentDetails(event.old);
 
-        if (areEnvironmentsEqual(previousEnvironment, environment)) {
+        if (isDeepStrictEqual(previousEnvironment, environment)) {
           this.#activeEnvironments.remember(event.uri, environment);
           logger.debug(
             `Ignoring Python Environments change event because the active environment is unchanged for '${event.uri ?? "workspace"}'.`,
@@ -268,13 +268,6 @@ function createActiveEnvironmentCache() {
       return !unchanged;
     },
   };
-}
-
-function areEnvironmentsEqual(
-  left: PythonEnvironmentDetails | null,
-  right: PythonEnvironmentDetails | null,
-): boolean {
-  return isDeepStrictEqual(left, right);
 }
 
 export function checkInterpreterVersion(environment: PythonEnvironmentDetails): boolean | null {

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -1,79 +1,329 @@
-import { commands, Disposable, Event, EventEmitter } from "vscode";
+import { commands, type Disposable, type Event, EventEmitter, extensions, Uri } from "vscode";
+import {
+  PythonExtension as PythonExtensionApi,
+  type ResolvedEnvironment,
+} from "@vscode/python-extension";
+import type { PythonEnvironment, PythonEnvironmentApi } from "@vscode/python-environments";
 import { logger } from "./logger";
-import { PythonExtension, ResolvedEnvironment, Resource } from "@vscode/python-extension";
 
-export interface IInterpreterDetails {
-  path?: string[];
-  resource?: Resource;
+const onDidChangeActivePythonEnvironmentEvent =
+  new EventEmitter<OnDidChangeActivePythonEnvironmentEventArgs>();
+
+export type OnDidChangeActivePythonEnvironmentEventArgs = {
+  path?: string;
+  uri?: Uri;
+};
+
+export const onDidChangeActivePythonEnvironment: Event<OnDidChangeActivePythonEnvironmentEventArgs> =
+  onDidChangeActivePythonEnvironmentEvent.event;
+
+export type PythonCommand = {
+  executable: string;
+  args: string[];
+};
+
+export interface PythonEnvironmentDetails {
+  command: PythonCommand | null;
+  sysPrefix: string;
+  version: {
+    major: number;
+    minor: number;
+    patch: number | null;
+  } | null;
 }
 
-const onDidChangePythonInterpreterEvent = new EventEmitter<IInterpreterDetails>();
-export const onDidChangePythonInterpreter: Event<IInterpreterDetails> =
-  onDidChangePythonInterpreterEvent.event;
+export interface EnvironmentProvider {
+  initialize(disposables: Disposable[]): Promise<void>;
 
-let _api: PythonExtension | undefined;
-async function getPythonExtensionAPI(): Promise<PythonExtension | undefined> {
-  if (_api) {
-    return _api;
+  /** Resolve a Python executable or environment directory to an environment. */
+  resolveInterpreter(path: string): Promise<PythonEnvironmentDetails | null>;
+
+  /** Resolve the active Python environment for a file, folder, or workspace. */
+  getActiveEnvironment(uri?: Uri): Promise<PythonEnvironmentDetails | null>;
+}
+
+export async function getEnvironmentProvider(): Promise<EnvironmentProvider | null> {
+  return (await getPythonEnvironmentExtension()) ?? (await getPythonExtension());
+}
+
+let pythonExtensionApi: PythonExtensionApi | undefined;
+
+async function getPythonExtensionAPI(): Promise<PythonExtensionApi> {
+  pythonExtensionApi ??= await PythonExtensionApi.api();
+  return pythonExtensionApi;
+}
+
+/** Facade for the traditional Python extension environment API. */
+class PythonExtension implements EnvironmentProvider {
+  readonly #extension: PythonExtensionApi;
+
+  private constructor(extension: PythonExtensionApi) {
+    this.#extension = extension;
   }
-  _api = await PythonExtension.api();
-  return _api;
-}
 
-export async function initializePython(disposables: Disposable[]): Promise<void> {
-  try {
-    const api = await getPythonExtensionAPI();
+  static async tryActivate(): Promise<PythonExtension | null> {
+    logger.info("Initializing Python extension");
 
-    if (api) {
-      disposables.push(
-        api.environments.onDidChangeActiveEnvironmentPath((e) => {
-          onDidChangePythonInterpreterEvent.fire({ path: [e.path], resource: e.resource });
-        }),
-      );
-
-      logger.info("Waiting for interpreter from python extension.");
-      onDidChangePythonInterpreterEvent.fire(await getInterpreterDetails());
+    try {
+      return new PythonExtension(await getPythonExtensionAPI());
+    } catch (error) {
+      logger.error("Error initializing the Python extension: ", error);
+      return null;
     }
-  } catch (error) {
-    logger.error("Error initializing python: ", error);
+  }
+
+  async initialize(disposables: Disposable[]): Promise<void> {
+    logger.info("Using Python extension for Python environment detection");
+    disposables.push(
+      this.#extension.environments.onDidChangeActiveEnvironmentPath((event) => {
+        onDidChangeActivePythonEnvironmentEvent.fire({
+          path: event.path,
+          uri: event.resource instanceof Uri ? event.resource : event.resource?.uri,
+        });
+      }),
+    );
+  }
+
+  async resolveInterpreter(path: string): Promise<PythonEnvironmentDetails | null> {
+    const environment = await this.#extension.environments.resolveEnvironment(path);
+    return environment == null ? null : PythonExtension.toEnvironmentDetails(environment);
+  }
+
+  async getActiveEnvironment(uri?: Uri): Promise<PythonEnvironmentDetails | null> {
+    const environment = await this.#extension.environments.resolveEnvironment(
+      this.#extension.environments.getActiveEnvironmentPath(uri),
+    );
+    return environment == null ? null : PythonExtension.toEnvironmentDetails(environment);
+  }
+
+  private static toEnvironmentDetails(environment: ResolvedEnvironment): PythonEnvironmentDetails {
+    const version = environment.version;
+    const executable = environment.executable.uri?.fsPath;
+
+    return {
+      command: executable == null ? null : { executable, args: [] },
+      sysPrefix: environment.executable.sysPrefix,
+      version:
+        version == null
+          ? null
+          : {
+              major: version.major,
+              minor: version.minor,
+              patch: version.micro,
+            },
+    };
   }
 }
 
-export async function resolveInterpreter(
-  interpreter: string[],
-): Promise<ResolvedEnvironment | undefined> {
-  const api = await getPythonExtensionAPI();
-  return api?.environments.resolveEnvironment(interpreter[0]);
+const pythonExtension = lazyInit(PythonExtension.tryActivate);
+
+async function getPythonExtension(): Promise<PythonExtension | null> {
+  return pythonExtension.get();
 }
 
-export async function getInterpreterDetails(resource?: Resource): Promise<IInterpreterDetails> {
-  const api = await getPythonExtensionAPI();
-  const environment = await api?.environments.resolveEnvironment(
-    api?.environments.getActiveEnvironmentPath(resource),
-  );
-  if (environment?.executable.uri && checkVersion(environment)) {
-    return { path: [environment?.executable.uri.fsPath], resource };
+/** Facade for the dedicated Python Environments extension API. */
+class PythonEnvironmentExtension implements EnvironmentProvider {
+  readonly #extension: PythonEnvironmentApi;
+  readonly #activeEnvironments = createActiveEnvironmentCache();
+
+  private constructor(extension: PythonEnvironmentApi) {
+    this.#extension = extension;
   }
-  return { path: undefined, resource };
+
+  static async tryActivate(): Promise<PythonEnvironmentExtension | null> {
+    const extension = extensions.getExtension("ms-python.vscode-python-envs");
+
+    if (extension == null) {
+      logger.info("The Python Environments extension is not installed or is disabled.");
+      return null;
+    }
+
+    if (!extension.isActive) {
+      try {
+        logger.info("Activating the Python Environments extension");
+        await extension.activate();
+        logger.info("Successfully activated the Python Environments extension.");
+      } catch {
+        logger.warn("Failed to activate the Python Environments extension.");
+        return null;
+      }
+    }
+
+    // The extension exports no API when `python.useEnvironmentsExtension` is false.
+    if (extension.exports == null) {
+      logger.info(
+        "The Python Environments extension is disabled by 'python.useEnvironmentsExtension'.",
+      );
+      return null;
+    }
+
+    return new PythonEnvironmentExtension(extension.exports as PythonEnvironmentApi);
+  }
+
+  async initialize(disposables: Disposable[]): Promise<void> {
+    logger.info("Using Python Environments extension for Python environment detection");
+
+    await this.getActiveEnvironment(undefined);
+
+    disposables.push(
+      this.#extension.onDidChangeEnvironment((event) => {
+        logger.debug(`Python Environments didChangeEnvironment: ${JSON.stringify(event, null, 2)}`);
+
+        const environment = event.new == null ? null : this.toEnvironmentDetails(event.new);
+        const previousEnvironment = event.old == null ? null : this.toEnvironmentDetails(event.old);
+
+        if (areEnvironmentsEqual(previousEnvironment, environment)) {
+          this.#activeEnvironments.remember(event.uri, environment);
+          logger.debug(
+            `Ignoring Python Environments change event because the active environment is unchanged for '${event.uri ?? "workspace"}'.`,
+          );
+          return;
+        }
+
+        if (!this.#activeEnvironments.record(event.uri, environment)) {
+          logger.debug(
+            `Ignoring Python Environments change event because the active environment is unchanged for '${event.uri ?? "workspace"}'.`,
+          );
+          return;
+        }
+
+        onDidChangeActivePythonEnvironmentEvent.fire({
+          path: environment?.command?.executable,
+          uri: event.uri,
+        });
+      }),
+    );
+  }
+
+  async resolveInterpreter(path: string): Promise<PythonEnvironmentDetails | null> {
+    const environment = await this.#extension.resolveEnvironment(Uri.file(path));
+    return environment == null ? null : this.toEnvironmentDetails(environment);
+  }
+
+  async getActiveEnvironment(uri?: Uri): Promise<PythonEnvironmentDetails | null> {
+    const environment = await this.#extension.getEnvironment(uri);
+    const details = environment == null ? null : this.toEnvironmentDetails(environment);
+
+    this.#activeEnvironments.remember(uri, details);
+    if (details != null) {
+      logger.debug(`Resolved Python environment: '${details.sysPrefix}'`);
+    }
+    return details;
+  }
+
+  private toEnvironmentDetails(environment: PythonEnvironment): PythonEnvironmentDetails | null {
+    if (environment.error) {
+      logger.warn(
+        `Ignoring environment '${environment.environmentPath}' with errors: ${environment.error}`,
+      );
+      return null;
+    }
+
+    return {
+      command: {
+        executable: environment.execInfo.run.executable,
+        args: environment.execInfo.run.args ?? [],
+      },
+      sysPrefix: environment.sysPrefix,
+      version: PythonEnvironmentExtension.parseVersion(environment.version),
+    };
+  }
+
+  private static parseVersion(version: string): PythonEnvironmentDetails["version"] {
+    const match = /^(\d+)\.(\d+)(?:\.(\d+))?/.exec(version);
+    if (match == null) {
+      return null;
+    }
+
+    return {
+      major: parseInt(match[1]),
+      minor: parseInt(match[2]),
+      patch: match[3] == null ? null : parseInt(match[3]),
+    };
+  }
+}
+
+const pythonEnvironmentExtension = lazyInit(PythonEnvironmentExtension.tryActivate);
+
+async function getPythonEnvironmentExtension(): Promise<PythonEnvironmentExtension | null> {
+  return pythonEnvironmentExtension.get();
+}
+
+function createActiveEnvironmentCache() {
+  const environments = new Map<string | symbol, string | null>();
+  const workspaceKey = Symbol("workspace");
+  const scopeKey = (uri: Uri | undefined) => uri?.toString() ?? workspaceKey;
+
+  return {
+    remember(uri: Uri | undefined, environment: PythonEnvironmentDetails | null): void {
+      environments.set(scopeKey(uri), environmentKey(environment));
+    },
+
+    record(uri: Uri | undefined, environment: PythonEnvironmentDetails | null): boolean {
+      const key = scopeKey(uri);
+      const next = environmentKey(environment);
+      const unchanged = environments.get(key) === next;
+      environments.set(key, next);
+      return !unchanged;
+    },
+  };
+}
+
+function areEnvironmentsEqual(
+  left: PythonEnvironmentDetails | null,
+  right: PythonEnvironmentDetails | null,
+): boolean {
+  return environmentKey(left) === environmentKey(right);
+}
+
+function environmentKey(environment: PythonEnvironmentDetails | null): string | null {
+  return environment == null ? null : JSON.stringify(environment);
+}
+
+export function checkInterpreterVersion(environment: PythonEnvironmentDetails): boolean | null {
+  const version = environment.version;
+  if (version == null) {
+    return null;
+  }
+  if (version.major === 3 && version.minor >= 8) {
+    return true;
+  }
+
+  logger.warn(`Python version ${version.major}.${version.minor} is not supported.`);
+  logger.warn(`Selected Python path: '${environment.command?.executable}'`);
+  logger.warn("Supported versions are 3.8 and above.");
+  return false;
 }
 
 export async function getDebuggerPath(): Promise<string | undefined> {
   const api = await getPythonExtensionAPI();
-  return api?.debug.getDebuggerPackagePath();
+  return api.debug.getDebuggerPackagePath();
 }
 
 export async function runPythonExtensionCommand(command: string, ...rest: any[]) {
   await getPythonExtensionAPI();
-  return await commands.executeCommand(command, ...rest);
+  return commands.executeCommand(command, ...rest);
 }
 
-export function checkVersion(resolved: ResolvedEnvironment): boolean {
-  const version = resolved.version;
-  if (version?.major === 3 && version?.minor >= 8) {
-    return true;
-  }
-  logger.error(`Python version ${version?.major}.${version?.minor} is not supported.`);
-  logger.error(`Selected python path: ${resolved.executable.uri?.fsPath}`);
-  logger.error("Supported versions are 3.8 and above.");
-  return false;
+const unavailable = Symbol("unavailable");
+
+function lazyInit<T>(factory: () => Promise<T | null>): { get(): Promise<T | null> } {
+  let cache: T | null | typeof unavailable = null;
+
+  return {
+    async get() {
+      if (cache === unavailable) {
+        return null;
+      }
+
+      const cached = cache ?? (await factory());
+      if (cached == null) {
+        cache = unavailable;
+        return null;
+      }
+
+      cache = cached;
+      return cached;
+    },
+  };
 }

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -1,4 +1,5 @@
-import { commands, type Disposable, type Event, EventEmitter, extensions, Uri } from "vscode";
+import { isDeepStrictEqual } from "node:util";
+import { type Disposable, type Event, EventEmitter, extensions, Uri } from "vscode";
 import {
   PythonExtension as PythonExtensionApi,
   type ResolvedEnvironment,
@@ -124,6 +125,7 @@ async function getPythonExtension(): Promise<PythonExtension | null> {
 /** Facade for the dedicated Python Environments extension API. */
 class PythonEnvironmentExtension implements EnvironmentProvider {
   readonly #extension: PythonEnvironmentApi;
+  // The extension emits duplicate change events, so only forward actual changes per scope.
   readonly #activeEnvironments = createActiveEnvironmentCache();
 
   private constructor(extension: PythonEnvironmentApi) {
@@ -250,20 +252,19 @@ async function getPythonEnvironmentExtension(): Promise<PythonEnvironmentExtensi
 }
 
 function createActiveEnvironmentCache() {
-  const environments = new Map<string | symbol, string | null>();
+  const environments = new Map<string | symbol, PythonEnvironmentDetails | null>();
   const workspaceKey = Symbol("workspace");
   const scopeKey = (uri: Uri | undefined) => uri?.toString() ?? workspaceKey;
 
   return {
     remember(uri: Uri | undefined, environment: PythonEnvironmentDetails | null): void {
-      environments.set(scopeKey(uri), environmentKey(environment));
+      environments.set(scopeKey(uri), environment);
     },
 
     record(uri: Uri | undefined, environment: PythonEnvironmentDetails | null): boolean {
       const key = scopeKey(uri);
-      const next = environmentKey(environment);
-      const unchanged = environments.get(key) === next;
-      environments.set(key, next);
+      const unchanged = isDeepStrictEqual(environments.get(key), environment);
+      environments.set(key, environment);
       return !unchanged;
     },
   };
@@ -273,11 +274,7 @@ function areEnvironmentsEqual(
   left: PythonEnvironmentDetails | null,
   right: PythonEnvironmentDetails | null,
 ): boolean {
-  return environmentKey(left) === environmentKey(right);
-}
-
-function environmentKey(environment: PythonEnvironmentDetails | null): string | null {
-  return environment == null ? null : JSON.stringify(environment);
+  return isDeepStrictEqual(left, right);
 }
 
 export function checkInterpreterVersion(environment: PythonEnvironmentDetails): boolean | null {
@@ -298,11 +295,6 @@ export function checkInterpreterVersion(environment: PythonEnvironmentDetails): 
 export async function getDebuggerPath(): Promise<string | undefined> {
   const api = await getPythonExtensionAPI();
   return api.debug.getDebuggerPackagePath();
-}
-
-export async function runPythonExtensionCommand(command: string, ...rest: any[]) {
-  await getPythonExtensionAPI();
-  return commands.executeCommand(command, ...rest);
 }
 
 const unavailable = Symbol("unavailable");

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -376,7 +376,7 @@ type RuffExecutable = {
   version: VersionInfo;
 };
 
-type ServerExecution =
+type ServerResolution =
   | {
       kind: "native";
       executable: RuffExecutable;
@@ -390,7 +390,7 @@ type ServerExecution =
 
 export type ServerState = {
   client: LanguageClient;
-  execution: ServerExecution;
+  resolution: ServerResolution;
 };
 
 const RUFF_LSP_URL = "https://github.com/astral-sh/ruff-lsp";
@@ -581,14 +581,14 @@ async function resolveLegacyInterpreter(
   return { command, dependsOnActiveInterpreter };
 }
 
-export async function resolveServerExecution(
+export async function resolveServer(
   settings: ISettings,
   projectRoot: vscode.WorkspaceFolder,
   serverId: string,
   environmentProvider: EnvironmentProvider | null,
   activeEnvironment: PythonEnvironmentDetails | null,
   showWarnings: boolean,
-): Promise<ServerExecution | null> {
+): Promise<ServerResolution | null> {
   const serverSetting = await resolveNativeServerSetting(
     settings,
     projectRoot,
@@ -640,10 +640,10 @@ async function createServer(
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
   initializationOptions: IInitializationOptions,
-  execution: ServerExecution,
+  resolution: ServerResolution,
 ): Promise<LanguageClient> {
-  updateServerKind(execution.kind === "native");
-  if (execution.kind === "native") {
+  updateServerKind(resolution.kind === "native");
+  if (resolution.kind === "native") {
     return createNativeServer(
       settings,
       serverId,
@@ -651,7 +651,7 @@ async function createServer(
       outputChannel,
       traceOutputChannel,
       initializationOptions,
-      execution.executable,
+      resolution.executable,
     );
   } else {
     return createLegacyServer(
@@ -661,7 +661,7 @@ async function createServer(
       outputChannel,
       traceOutputChannel,
       initializationOptions,
-      execution.interpreter,
+      resolution.interpreter,
     );
   }
 }
@@ -681,7 +681,7 @@ export async function startServer(
 
   const activeEnvironment =
     (await environmentProvider?.getActiveEnvironment(projectRoot.uri)) ?? null;
-  const execution = await resolveServerExecution(
+  const resolution = await resolveServer(
     workspaceSettings,
     projectRoot,
     serverId,
@@ -689,7 +689,7 @@ export async function startServer(
     activeEnvironment,
     true,
   );
-  if (execution == null) {
+  if (resolution == null) {
     return null;
   }
 
@@ -710,7 +710,7 @@ export async function startServer(
       settings: extensionSettings,
       globalSettings: globalSettings,
     },
-    execution,
+    resolution,
   );
   logger.info(`Server: Start requested.`);
 
@@ -753,7 +753,7 @@ export async function startServer(
     return null;
   }
 
-  return { client: newLSClient, execution };
+  return { client: newLSClient, resolution };
 }
 
 export async function stopServer(lsClient: LanguageClient): Promise<void> {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -380,12 +380,12 @@ function showWarningMessage(message: string) {
   logger.warn(message);
 }
 
-export type RuffExecutable = {
+type RuffExecutable = {
   path: string;
   version: VersionInfo;
 };
 
-export type ServerPlan =
+type ServerExecution =
   | {
       kind: "native";
       executable: RuffExecutable;
@@ -394,13 +394,12 @@ export type ServerPlan =
   | {
       kind: "legacy";
       interpreter: PythonCommand;
-      autoRuffExecutable: RuffExecutable | null;
       dependsOnActiveInterpreter: boolean;
     };
 
 export type ServerState = {
   client: LanguageClient;
-  plan: ServerPlan;
+  execution: ServerExecution;
 };
 
 const RUFF_LSP_URL = "https://github.com/astral-sh/ruff-lsp";
@@ -421,8 +420,8 @@ async function resolveNativeServerSetting(
   showWarnings: boolean,
 ): Promise<{
   useNativeServer: boolean;
-  executable: RuffExecutable | null;
-  dependsOnActiveInterpreter: boolean;
+  executable?: RuffExecutable;
+  dependsOnActiveInterpreter?: boolean;
 }> {
   let useNativeServer: boolean;
   let legacyServerSettings: LegacyServerSetting[];
@@ -440,11 +439,7 @@ async function resolveNativeServerSetting(
             LSP_DEPRECATION_DISCUSSION_MESSAGE,
         );
       }
-      return {
-        useNativeServer: true,
-        executable: null,
-        dependsOnActiveInterpreter: false,
-      };
+      return { useNativeServer: true };
     case "off":
     case false:
       if (!vscode.workspace.isTrusted) {
@@ -455,11 +450,7 @@ async function resolveNativeServerSetting(
           vscode.window.showWarningMessage(message);
           logger.warn(message);
         }
-        return {
-          useNativeServer: true,
-          executable: null,
-          dependsOnActiveInterpreter: false,
-        };
+        return { useNativeServer: true };
       }
 
       // User has explicitly set the native server to 'off'. Recommend them to upgrade to the native server ...
@@ -478,21 +469,13 @@ async function resolveNativeServerSetting(
         showWarningMessage(message);
       }
 
-      return {
-        useNativeServer: false,
-        executable: null,
-        dependsOnActiveInterpreter: false,
-      };
+      return { useNativeServer: false };
     case "auto":
       if (!vscode.workspace.isTrusted) {
         logger.info(
           `Resolved '${serverId}.nativeServer: auto' to use the native server in an untrusted workspace`,
         );
-        return {
-          useNativeServer: true,
-          executable: null,
-          dependsOnActiveInterpreter: false,
-        };
+        return { useNativeServer: true };
       }
 
       const binaryResolution = await findRuffBinaryPath(
@@ -546,21 +529,6 @@ async function resolveNativeServerSetting(
         dependsOnActiveInterpreter: binaryResolution.dependsOnActiveInterpreter,
       };
   }
-}
-
-async function resolveRuffExecutable(
-  settings: ISettings,
-  environmentProvider: EnvironmentProvider | null,
-  activeEnvironment: PythonEnvironmentDetails | null,
-): Promise<{ executable: RuffExecutable; dependsOnActiveInterpreter: boolean }> {
-  const resolution = await findRuffBinaryPath(settings, environmentProvider, activeEnvironment);
-  return {
-    executable: {
-      path: resolution.path,
-      version: await getRuffVersion(resolution.path),
-    },
-    dependsOnActiveInterpreter: resolution.dependsOnActiveInterpreter,
-  };
 }
 
 async function resolveLegacyInterpreter(
@@ -627,14 +595,14 @@ async function resolveLegacyInterpreter(
   return { command, dependsOnActiveInterpreter };
 }
 
-export async function resolveServerPlan(
+export async function resolveServerExecution(
   settings: ISettings,
   projectRoot: vscode.WorkspaceFolder,
   serverId: string,
   environmentProvider: EnvironmentProvider | null,
   activeEnvironment: PythonEnvironmentDetails | null,
   showWarnings: boolean,
-): Promise<ServerPlan | null> {
+): Promise<ServerExecution | null> {
   const serverSetting = await resolveNativeServerSetting(
     settings,
     projectRoot,
@@ -645,17 +613,20 @@ export async function resolveServerPlan(
   );
 
   if (serverSetting.useNativeServer) {
-    const resolution =
-      serverSetting.executable == null
-        ? await resolveRuffExecutable(settings, environmentProvider, activeEnvironment)
-        : {
-            executable: serverSetting.executable,
-            dependsOnActiveInterpreter: serverSetting.dependsOnActiveInterpreter,
-          };
+    let executable = serverSetting.executable;
+    let dependsOnActiveInterpreter = serverSetting.dependsOnActiveInterpreter ?? false;
+    if (executable == null) {
+      const resolution = await findRuffBinaryPath(settings, environmentProvider, activeEnvironment);
+      executable = {
+        path: resolution.path,
+        version: await getRuffVersion(resolution.path),
+      };
+      dependsOnActiveInterpreter = resolution.dependsOnActiveInterpreter;
+    }
     return {
       kind: "native",
-      executable: resolution.executable,
-      dependsOnActiveInterpreter: resolution.dependsOnActiveInterpreter,
+      executable,
+      dependsOnActiveInterpreter,
     };
   }
 
@@ -671,14 +642,9 @@ export async function resolveServerPlan(
   return {
     kind: "legacy",
     interpreter: interpreter.command,
-    autoRuffExecutable: serverSetting.executable,
     dependsOnActiveInterpreter:
-      serverSetting.dependsOnActiveInterpreter || interpreter.dependsOnActiveInterpreter,
+      (serverSetting.dependsOnActiveInterpreter ?? false) || interpreter.dependsOnActiveInterpreter,
   };
-}
-
-export function serverPlanKey(plan: ServerPlan): string {
-  return JSON.stringify(plan);
 }
 
 async function createServer(
@@ -688,10 +654,10 @@ async function createServer(
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
   initializationOptions: IInitializationOptions,
-  plan: ServerPlan,
+  execution: ServerExecution,
 ): Promise<LanguageClient> {
-  updateServerKind(plan.kind === "native");
-  if (plan.kind === "native") {
+  updateServerKind(execution.kind === "native");
+  if (execution.kind === "native") {
     return createNativeServer(
       settings,
       serverId,
@@ -699,7 +665,7 @@ async function createServer(
       outputChannel,
       traceOutputChannel,
       initializationOptions,
-      plan.executable,
+      execution.executable,
     );
   } else {
     return createLegacyServer(
@@ -709,7 +675,7 @@ async function createServer(
       outputChannel,
       traceOutputChannel,
       initializationOptions,
-      plan.interpreter,
+      execution.interpreter,
     );
   }
 }
@@ -729,7 +695,7 @@ export async function startServer(
 
   const activeEnvironment =
     (await environmentProvider?.getActiveEnvironment(projectRoot.uri)) ?? null;
-  const plan = await resolveServerPlan(
+  const execution = await resolveServerExecution(
     workspaceSettings,
     projectRoot,
     serverId,
@@ -737,7 +703,7 @@ export async function startServer(
     activeEnvironment,
     true,
   );
-  if (plan == null) {
+  if (execution == null) {
     return null;
   }
 
@@ -758,7 +724,7 @@ export async function startServer(
       settings: extensionSettings,
       globalSettings: globalSettings,
     },
-    plan,
+    execution,
   );
   logger.info(`Server: Start requested.`);
 
@@ -801,7 +767,7 @@ export async function startServer(
     return null;
   }
 
-  return { client: newLSClient, plan };
+  return { client: newLSClient, execution };
 }
 
 export async function stopServer(lsClient: LanguageClient): Promise<void> {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -19,7 +19,13 @@ import {
   RUFF_BINARY_NAME,
 } from "./constants";
 import { logger } from "./logger";
-import { getDebuggerPath } from "./python";
+import {
+  checkInterpreterVersion,
+  type EnvironmentProvider,
+  getDebuggerPath,
+  type PythonCommand,
+  type PythonEnvironmentDetails,
+} from "./python";
 import {
   checkInlineConfigSupport,
   getExtensionSettings,
@@ -100,10 +106,68 @@ async function getRuffVersion(executable: string): Promise<VersionInfo> {
  *    which checks the PATH environment variable.
  * 5. If all else fails, return the bundled executable path.
  */
-async function findRuffBinaryPath(settings: ISettings): Promise<string> {
+export type BinaryResolution = {
+  path: string;
+  dependsOnActiveInterpreter: boolean;
+};
+
+export async function resolvePythonEnvironment(
+  configuredInterpreter: string[],
+  workspace: string,
+  environmentProvider: EnvironmentProvider | null,
+  activeEnvironment: PythonEnvironmentDetails | null,
+  fallBackToActiveEnvironment: boolean,
+): Promise<{
+  environment: PythonEnvironmentDetails | null;
+  dependsOnActiveInterpreter: boolean;
+}> {
+  if (environmentProvider == null) {
+    return { environment: null, dependsOnActiveInterpreter: false };
+  }
+
+  const configuredPath = configuredInterpreter[0];
+  if (configuredPath != null) {
+    logger.info(`Resolving Python interpreter from 'ruff.interpreter': '${configuredPath}'`);
+    const environment = await environmentProvider.resolveInterpreter(configuredPath);
+    if (environment != null) {
+      return { environment, dependsOnActiveInterpreter: false };
+    }
+
+    logger.warn(`'${configuredPath}' (from 'ruff.interpreter') is not a valid interpreter.`);
+    if (!fallBackToActiveEnvironment) {
+      return { environment: null, dependsOnActiveInterpreter: false };
+    }
+    logger.warn("Falling back to the active Python environment.");
+  }
+
+  logger.info(`Resolving active Python environment for workspace: '${workspace}'`);
+  if (activeEnvironment == null) {
+    logger.warn("No active Python environment found.");
+  }
+  return { environment: activeEnvironment, dependsOnActiveInterpreter: true };
+}
+
+function resolvePythonCommand(
+  environment: PythonEnvironmentDetails,
+  additionalArgs: string[],
+): PythonCommand | null {
+  if (environment.command == null) {
+    return null;
+  }
+  return {
+    executable: environment.command.executable,
+    args: [...environment.command.args, ...additionalArgs],
+  };
+}
+
+export async function findRuffBinaryPath(
+  settings: ISettings,
+  environmentProvider: EnvironmentProvider | null,
+  activeEnvironment: PythonEnvironmentDetails | null,
+): Promise<BinaryResolution> {
   if (!vscode.workspace.isTrusted) {
     logger.info(`Workspace is not trusted, using bundled executable: ${BUNDLED_RUFF_EXECUTABLE}`);
-    return BUNDLED_RUFF_EXECUTABLE;
+    return { path: BUNDLED_RUFF_EXECUTABLE, dependsOnActiveInterpreter: false };
   }
 
   // 'path' setting takes priority over everything.
@@ -111,7 +175,7 @@ async function findRuffBinaryPath(settings: ISettings): Promise<string> {
     for (const path of settings.path) {
       if (await fsapi.pathExists(path)) {
         logger.info(`Using 'path' setting: ${path}`);
-        return path;
+        return { path, dependsOnActiveInterpreter: false };
       }
     }
     logger.info(`Could not find executable in 'path': ${settings.path.join(", ")}`);
@@ -119,44 +183,70 @@ async function findRuffBinaryPath(settings: ISettings): Promise<string> {
 
   if (settings.importStrategy === "useBundled") {
     logger.info(`Using bundled executable: ${BUNDLED_RUFF_EXECUTABLE}`);
-    return BUNDLED_RUFF_EXECUTABLE;
+    return { path: BUNDLED_RUFF_EXECUTABLE, dependsOnActiveInterpreter: false };
   }
 
   // Otherwise, we'll call a Python script that tries to locate a binary.
   let ruffBinaryPath: string | undefined;
-  try {
-    const stdout = await executeFile(settings.interpreter[0], [FIND_RUFF_BINARY_SCRIPT_PATH]);
-    ruffBinaryPath = stdout.trim();
-  } catch (err) {
-    vscode.window
-      .showErrorMessage(
-        "Unexpected error while trying to find the Ruff binary. See the logs for more details.",
-        "Show Logs",
-      )
-      .then((selection) => {
-        if (selection) {
-          logger.channel.show();
-        }
-      });
-    logger.error(`Error while trying to find the Ruff binary: ${err}`);
+  const { environment, dependsOnActiveInterpreter } = await resolvePythonEnvironment(
+    settings.interpreter,
+    settings.workspace,
+    environmentProvider,
+    activeEnvironment,
+    true,
+  );
+
+  if (environment != null) {
+    const command = resolvePythonCommand(
+      environment,
+      dependsOnActiveInterpreter ? [] : settings.interpreter.slice(1),
+    );
+    if (command == null) {
+      logger.warn("Resolved Python environment has no executable command.");
+    } else if (checkInterpreterVersion(environment)) {
+      logger.info(`Resolved Python executable for Ruff lookup: '${command.executable}'`);
+      try {
+        const stdout = await executeFile(command.executable, [
+          ...command.args,
+          FIND_RUFF_BINARY_SCRIPT_PATH,
+        ]);
+        ruffBinaryPath = stdout.trim();
+      } catch (err) {
+        vscode.window
+          .showErrorMessage(
+            "Unexpected error while trying to find the Ruff binary. See the logs for more details.",
+            "Show Logs",
+          )
+          .then((selection) => {
+            if (selection) {
+              logger.channel.show();
+            }
+          });
+        logger.error(`Error while trying to find the Ruff binary: ${err}`);
+      }
+    } else {
+      logger.warn(
+        "Skipping lookup of the Ruff executable in the Python environment because its Python version is unsupported or unknown.",
+      );
+    }
   }
 
   if (ruffBinaryPath && ruffBinaryPath.length > 0) {
     // First choice: the executable found by the script.
     logger.info(`Using the Ruff binary: ${ruffBinaryPath}`);
-    return ruffBinaryPath;
+    return { path: ruffBinaryPath, dependsOnActiveInterpreter };
   }
 
   // Second choice: the executable in the global environment.
   const environmentPath = await which(RUFF_BINARY_NAME, { nothrow: true });
   if (environmentPath) {
     logger.info(`Using environment executable: ${environmentPath}`);
-    return environmentPath;
+    return { path: environmentPath, dependsOnActiveInterpreter };
   }
 
   // Third choice: bundled executable.
   logger.info(`Falling back to bundled executable: ${BUNDLED_RUFF_EXECUTABLE}`);
-  return BUNDLED_RUFF_EXECUTABLE;
+  return { path: BUNDLED_RUFF_EXECUTABLE, dependsOnActiveInterpreter };
 }
 
 async function createNativeServer(
@@ -166,13 +256,8 @@ async function createNativeServer(
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
   initializationOptions: IInitializationOptions,
-  ruffExecutable?: RuffExecutable,
+  ruffExecutable: RuffExecutable,
 ): Promise<LanguageClient> {
-  if (!ruffExecutable) {
-    const ruffBinaryPath = await findRuffBinaryPath(settings);
-    const ruffVersion = await getRuffVersion(ruffBinaryPath);
-    ruffExecutable = { path: ruffBinaryPath, version: ruffVersion };
-  }
   const { path: ruffBinaryPath, version: ruffVersion } = ruffExecutable;
 
   logger.info(`Found Ruff ${versionToString(ruffVersion)} at ${ruffBinaryPath}`);
@@ -236,13 +321,19 @@ async function createLegacyServer(
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
   initializationOptions: IInitializationOptions,
+  interpreter: PythonCommand,
 ): Promise<LanguageClient> {
-  const command = settings.interpreter[0];
+  const command = interpreter.executable;
   const cwd = settings.cwd;
 
   // Set debugger path needed for debugging python code.
   const newEnv = { ...process.env };
-  const debuggerPath = await getDebuggerPath();
+  let debuggerPath: string | undefined;
+  try {
+    debuggerPath = await getDebuggerPath();
+  } catch (error) {
+    logger.warn(`Unable to resolve the Python debugger path: ${error}`);
+  }
   const isDebugScript = await fsapi.pathExists(DEBUG_SERVER_SCRIPT_PATH);
   if (newEnv.USE_DEBUGPY && debuggerPath) {
     newEnv.DEBUGPY_PATH = debuggerPath;
@@ -257,8 +348,8 @@ async function createLegacyServer(
 
   const args =
     newEnv.USE_DEBUGPY === "False" || !isDebugScript
-      ? settings.interpreter.slice(1).concat([RUFF_LSP_SERVER_SCRIPT_PATH])
-      : settings.interpreter.slice(1).concat([DEBUG_SERVER_SCRIPT_PATH]);
+      ? interpreter.args.concat([RUFF_LSP_SERVER_SCRIPT_PATH])
+      : interpreter.args.concat([DEBUG_SERVER_SCRIPT_PATH]);
   logger.info(`Server run command: ${[command, ...args].join(" ")}`);
 
   const serverOptions: ServerOptions = {
@@ -289,9 +380,27 @@ function showWarningMessage(message: string) {
   logger.warn(message);
 }
 
-type RuffExecutable = {
+export type RuffExecutable = {
   path: string;
   version: VersionInfo;
+};
+
+export type ServerPlan =
+  | {
+      kind: "native";
+      executable: RuffExecutable;
+      dependsOnActiveInterpreter: boolean;
+    }
+  | {
+      kind: "legacy";
+      interpreter: PythonCommand;
+      autoRuffExecutable: RuffExecutable | null;
+      dependsOnActiveInterpreter: boolean;
+    };
+
+export type ServerState = {
+  client: LanguageClient;
+  plan: ServerPlan;
 };
 
 const RUFF_LSP_URL = "https://github.com/astral-sh/ruff-lsp";
@@ -307,16 +416,22 @@ async function resolveNativeServerSetting(
   settings: ISettings,
   workspace: vscode.WorkspaceFolder,
   serverId: string,
-): Promise<{ useNativeServer: boolean; executable: RuffExecutable | undefined }> {
+  environmentProvider: EnvironmentProvider | null,
+  activeEnvironment: PythonEnvironmentDetails | null,
+  showWarnings: boolean,
+): Promise<{
+  useNativeServer: boolean;
+  executable: RuffExecutable | null;
+  dependsOnActiveInterpreter: boolean;
+}> {
   let useNativeServer: boolean;
-  let executable: RuffExecutable | undefined;
   let legacyServerSettings: LegacyServerSetting[];
 
   switch (settings.nativeServer) {
     case "on":
     case true:
       legacyServerSettings = getUserSetLegacyServerSettings(serverId, workspace);
-      if (legacyServerSettings.length > 0) {
+      if (showWarnings && legacyServerSettings.length > 0) {
         // User has explicitly set the native server to 'on' but still has legacy server settings.
         showWarningMessage(
           `The following settings have been deprecated in the native server: ${formatLegacyServerSettings(
@@ -325,16 +440,26 @@ async function resolveNativeServerSetting(
             LSP_DEPRECATION_DISCUSSION_MESSAGE,
         );
       }
-      return { useNativeServer: true, executable };
+      return {
+        useNativeServer: true,
+        executable: null,
+        dependsOnActiveInterpreter: false,
+      };
     case "off":
     case false:
       if (!vscode.workspace.isTrusted) {
         const message =
           `Cannot use the legacy server ([ruff-lsp](${RUFF_LSP_URL})) in an untrusted workspace; ` +
           "switching to the native server using the bundled executable.";
-        vscode.window.showWarningMessage(message);
-        logger.warn(message);
-        return { useNativeServer: true, executable };
+        if (showWarnings) {
+          vscode.window.showWarningMessage(message);
+          logger.warn(message);
+        }
+        return {
+          useNativeServer: true,
+          executable: null,
+          dependsOnActiveInterpreter: false,
+        };
       }
 
       // User has explicitly set the native server to 'off'. Recommend them to upgrade to the native server ...
@@ -349,19 +474,34 @@ async function resolveNativeServerSetting(
         )}. Please [migrate](${LSP_MIGRATION_URL}) to the new settings or remove them. `;
       }
       message += LSP_DEPRECATION_DISCUSSION_MESSAGE;
-      showWarningMessage(message);
+      if (showWarnings) {
+        showWarningMessage(message);
+      }
 
-      return { useNativeServer: false, executable };
+      return {
+        useNativeServer: false,
+        executable: null,
+        dependsOnActiveInterpreter: false,
+      };
     case "auto":
       if (!vscode.workspace.isTrusted) {
         logger.info(
           `Resolved '${serverId}.nativeServer: auto' to use the native server in an untrusted workspace`,
         );
-        return { useNativeServer: true, executable };
+        return {
+          useNativeServer: true,
+          executable: null,
+          dependsOnActiveInterpreter: false,
+        };
       }
 
-      const ruffBinaryPath = await findRuffBinaryPath(settings);
-      const ruffVersion = await getRuffVersion(ruffBinaryPath);
+      const binaryResolution = await findRuffBinaryPath(
+        settings,
+        environmentProvider,
+        activeEnvironment,
+      );
+      const ruffBinaryPath = binaryResolution.path;
+      const ruffVersion = await getRuffVersion(binaryResolution.path);
 
       // Start with the assumption that the native server will be used.
       useNativeServer = true;
@@ -378,7 +518,7 @@ async function resolveNativeServerSetting(
         useNativeServer = false;
       }
 
-      if (!useNativeServer) {
+      if (showWarnings && !useNativeServer) {
         let message = `The legacy server ([ruff-lsp](${RUFF_LSP_URL})) has been deprecated. `;
         if (legacyServerSettings.length > 0) {
           message += `The following settings were only supported by the legacy server and has been deprecated: ${formatLegacyServerSettings(
@@ -400,27 +540,158 @@ async function resolveNativeServerSetting(
           useNativeServer ? "native" : "legacy (ruff-lsp)"
         } server`,
       );
-      return { useNativeServer, executable: { path: ruffBinaryPath, version: ruffVersion } };
+      return {
+        useNativeServer,
+        executable: { path: ruffBinaryPath, version: ruffVersion },
+        dependsOnActiveInterpreter: binaryResolution.dependsOnActiveInterpreter,
+      };
   }
+}
+
+async function resolveRuffExecutable(
+  settings: ISettings,
+  environmentProvider: EnvironmentProvider | null,
+  activeEnvironment: PythonEnvironmentDetails | null,
+): Promise<{ executable: RuffExecutable; dependsOnActiveInterpreter: boolean }> {
+  const resolution = await findRuffBinaryPath(settings, environmentProvider, activeEnvironment);
+  return {
+    executable: {
+      path: resolution.path,
+      version: await getRuffVersion(resolution.path),
+    },
+    dependsOnActiveInterpreter: resolution.dependsOnActiveInterpreter,
+  };
+}
+
+async function resolveLegacyInterpreter(
+  settings: ISettings,
+  environmentProvider: EnvironmentProvider | null,
+  activeEnvironment: PythonEnvironmentDetails | null,
+): Promise<{ command: PythonCommand; dependsOnActiveInterpreter: boolean } | null> {
+  const { environment, dependsOnActiveInterpreter } = await resolvePythonEnvironment(
+    settings.interpreter,
+    settings.workspace,
+    environmentProvider,
+    activeEnvironment,
+    false,
+  );
+
+  if (environment == null) {
+    const configuredPath = settings.interpreter[0];
+    if (configuredPath == null) {
+      updateStatus(
+        vscode.l10n.t("Please select a Python interpreter."),
+        vscode.LanguageStatusSeverity.Error,
+      );
+      logger.error(
+        "Python interpreter missing:\r\n" +
+          "[Option 1] Select a Python interpreter using the Python extension.\r\n" +
+          `[Option 2] Set an interpreter using the "ruff.interpreter" setting.\r\n` +
+          "Please use Python 3.8 or greater.",
+      );
+    } else {
+      updateStatus(
+        vscode.l10n.t("Python interpreter not found."),
+        vscode.LanguageStatusSeverity.Error,
+      );
+      logger.error(`Unable to resolve the configured Python interpreter: '${configuredPath}'`);
+    }
+    return null;
+  }
+
+  const supportedVersion = checkInterpreterVersion(environment);
+  if (supportedVersion !== true) {
+    updateStatus(
+      vscode.l10n.t("Python interpreter is unsupported."),
+      vscode.LanguageStatusSeverity.Error,
+    );
+    if (supportedVersion == null) {
+      logger.error("Unable to determine the selected Python interpreter version.");
+    }
+    return null;
+  }
+
+  const command = resolvePythonCommand(
+    environment,
+    dependsOnActiveInterpreter ? [] : settings.interpreter.slice(1),
+  );
+  if (command == null) {
+    updateStatus(
+      vscode.l10n.t("Python interpreter not found."),
+      vscode.LanguageStatusSeverity.Error,
+    );
+    logger.error("Resolved Python environment has no executable command.");
+    return null;
+  }
+
+  return { command, dependsOnActiveInterpreter };
+}
+
+export async function resolveServerPlan(
+  settings: ISettings,
+  projectRoot: vscode.WorkspaceFolder,
+  serverId: string,
+  environmentProvider: EnvironmentProvider | null,
+  activeEnvironment: PythonEnvironmentDetails | null,
+  showWarnings: boolean,
+): Promise<ServerPlan | null> {
+  const serverSetting = await resolveNativeServerSetting(
+    settings,
+    projectRoot,
+    serverId,
+    environmentProvider,
+    activeEnvironment,
+    showWarnings,
+  );
+
+  if (serverSetting.useNativeServer) {
+    const resolution =
+      serverSetting.executable == null
+        ? await resolveRuffExecutable(settings, environmentProvider, activeEnvironment)
+        : {
+            executable: serverSetting.executable,
+            dependsOnActiveInterpreter: serverSetting.dependsOnActiveInterpreter,
+          };
+    return {
+      kind: "native",
+      executable: resolution.executable,
+      dependsOnActiveInterpreter: resolution.dependsOnActiveInterpreter,
+    };
+  }
+
+  const interpreter = await resolveLegacyInterpreter(
+    settings,
+    environmentProvider,
+    activeEnvironment,
+  );
+  if (interpreter == null) {
+    return null;
+  }
+
+  return {
+    kind: "legacy",
+    interpreter: interpreter.command,
+    autoRuffExecutable: serverSetting.executable,
+    dependsOnActiveInterpreter:
+      serverSetting.dependsOnActiveInterpreter || interpreter.dependsOnActiveInterpreter,
+  };
+}
+
+export function serverPlanKey(plan: ServerPlan): string {
+  return JSON.stringify(plan);
 }
 
 async function createServer(
   settings: ISettings,
-  projectRoot: vscode.WorkspaceFolder,
   serverId: string,
   serverName: string,
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
   initializationOptions: IInitializationOptions,
+  plan: ServerPlan,
 ): Promise<LanguageClient> {
-  const { useNativeServer, executable } = await resolveNativeServerSetting(
-    settings,
-    projectRoot,
-    serverId,
-  );
-
-  updateServerKind(useNativeServer);
-  if (useNativeServer) {
+  updateServerKind(plan.kind === "native");
+  if (plan.kind === "native") {
     return createNativeServer(
       settings,
       serverId,
@@ -428,7 +699,7 @@ async function createServer(
       outputChannel,
       traceOutputChannel,
       initializationOptions,
-      executable,
+      plan.executable,
     );
   } else {
     return createLegacyServer(
@@ -438,6 +709,7 @@ async function createServer(
       outputChannel,
       traceOutputChannel,
       initializationOptions,
+      plan.interpreter,
     );
   }
 }
@@ -451,8 +723,23 @@ export async function startServer(
   serverName: string,
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
-): Promise<LanguageClient | undefined> {
+  environmentProvider: EnvironmentProvider | null,
+): Promise<ServerState | null> {
   updateStatus(undefined, LanguageStatusSeverity.Information, true);
+
+  const activeEnvironment =
+    (await environmentProvider?.getActiveEnvironment(projectRoot.uri)) ?? null;
+  const plan = await resolveServerPlan(
+    workspaceSettings,
+    projectRoot,
+    serverId,
+    environmentProvider,
+    activeEnvironment,
+    true,
+  );
+  if (plan == null) {
+    return null;
+  }
 
   const extensionSettings = await getExtensionSettings(serverId);
   for (const settings of extensionSettings) {
@@ -463,7 +750,6 @@ export async function startServer(
 
   const newLSClient = await createServer(
     workspaceSettings,
-    projectRoot,
     serverId,
     serverName,
     outputChannel,
@@ -472,6 +758,7 @@ export async function startServer(
       settings: extensionSettings,
       globalSettings: globalSettings,
     },
+    plan,
   );
   logger.info(`Server: Start requested.`);
 
@@ -511,10 +798,10 @@ export async function startServer(
     updateStatus(l10n.t("Server failed to start."), LanguageStatusSeverity.Error);
     logger.error(`Server: Start failed: ${ex}`);
     dispose();
-    return undefined;
+    return null;
   }
 
-  return newLSClient;
+  return { client: newLSClient, plan };
 }
 
 export async function stopServer(lsClient: LanguageClient): Promise<void> {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -116,27 +116,32 @@ export async function resolvePythonEnvironment(
   workspace: string,
   environmentProvider: EnvironmentProvider | null,
   activeEnvironment: PythonEnvironmentDetails | null,
-  fallBackToActiveEnvironment: boolean,
 ): Promise<{
   environment: PythonEnvironmentDetails | null;
+  command: PythonCommand | null;
   dependsOnActiveInterpreter: boolean;
 }> {
   if (environmentProvider == null) {
-    return { environment: null, dependsOnActiveInterpreter: false };
+    return { environment: null, command: null, dependsOnActiveInterpreter: false };
   }
 
-  const configuredPath = configuredInterpreter[0];
+  const [configuredPath, ...configuredArgs] = configuredInterpreter;
   if (configuredPath != null) {
     logger.info(`Resolving Python interpreter from 'ruff.interpreter': '${configuredPath}'`);
     const environment = await environmentProvider.resolveInterpreter(configuredPath);
     if (environment != null) {
-      return { environment, dependsOnActiveInterpreter: false };
+      const command =
+        environment.command == null
+          ? null
+          : { ...environment.command, args: environment.command.args.concat(configuredArgs) };
+      return {
+        environment,
+        command,
+        dependsOnActiveInterpreter: false,
+      };
     }
 
     logger.warn(`'${configuredPath}' (from 'ruff.interpreter') is not a valid interpreter.`);
-    if (!fallBackToActiveEnvironment) {
-      return { environment: null, dependsOnActiveInterpreter: false };
-    }
     logger.warn("Falling back to the active Python environment.");
   }
 
@@ -144,19 +149,10 @@ export async function resolvePythonEnvironment(
   if (activeEnvironment == null) {
     logger.warn("No active Python environment found.");
   }
-  return { environment: activeEnvironment, dependsOnActiveInterpreter: true };
-}
-
-function resolvePythonCommand(
-  environment: PythonEnvironmentDetails,
-  additionalArgs: string[],
-): PythonCommand | null {
-  if (environment.command == null) {
-    return null;
-  }
   return {
-    executable: environment.command.executable,
-    args: [...environment.command.args, ...additionalArgs],
+    environment: activeEnvironment,
+    command: activeEnvironment?.command ?? null,
+    dependsOnActiveInterpreter: true,
   };
 }
 
@@ -188,19 +184,14 @@ export async function findRuffBinaryPath(
 
   // Otherwise, we'll call a Python script that tries to locate a binary.
   let ruffBinaryPath: string | undefined;
-  const { environment, dependsOnActiveInterpreter } = await resolvePythonEnvironment(
+  const { environment, command, dependsOnActiveInterpreter } = await resolvePythonEnvironment(
     settings.interpreter,
     settings.workspace,
     environmentProvider,
     activeEnvironment,
-    true,
   );
 
   if (environment != null) {
-    const command = resolvePythonCommand(
-      environment,
-      dependsOnActiveInterpreter ? [] : settings.interpreter.slice(1),
-    );
     if (command == null) {
       logger.warn("Resolved Python environment has no executable command.");
     } else if (checkInterpreterVersion(environment)) {
@@ -536,12 +527,11 @@ async function resolveLegacyInterpreter(
   environmentProvider: EnvironmentProvider | null,
   activeEnvironment: PythonEnvironmentDetails | null,
 ): Promise<{ command: PythonCommand; dependsOnActiveInterpreter: boolean } | null> {
-  const { environment, dependsOnActiveInterpreter } = await resolvePythonEnvironment(
+  const { environment, command, dependsOnActiveInterpreter } = await resolvePythonEnvironment(
     settings.interpreter,
     settings.workspace,
     environmentProvider,
     activeEnvironment,
-    false,
   );
 
   if (environment == null) {
@@ -579,10 +569,6 @@ async function resolveLegacyInterpreter(
     return null;
   }
 
-  const command = resolvePythonCommand(
-    environment,
-    dependsOnActiveInterpreter ? [] : settings.interpreter.slice(1),
-  );
   if (command == null) {
     updateStatus(
       vscode.l10n.t("Python interpreter not found."),

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -5,7 +5,6 @@ import {
   WorkspaceConfiguration,
   WorkspaceFolder,
 } from "vscode";
-import { getInterpreterDetails } from "./python";
 import { getConfiguration, getWorkspaceFolders } from "./vscodeapi";
 import { logger } from "./logger";
 import {
@@ -126,14 +125,10 @@ export async function getWorkspaceSettings(
 ): Promise<ISettings> {
   const config = getConfiguration(namespace, workspace.uri);
 
-  let interpreter: string[] = getInterpreterFromSetting(namespace, workspace) ?? [];
-  if (interpreter.length === 0) {
-    if (vscode.workspace.isTrusted) {
-      interpreter = (await getInterpreterDetails(workspace.uri)).path ?? [];
-    }
-  } else {
-    interpreter = resolveVariables(interpreter, workspace);
-  }
+  const interpreter = resolveVariables(
+    getInterpreterFromSetting(namespace, workspace) ?? [],
+    workspace,
+  );
 
   let configuration = config.get<string | object>("configuration") ?? null;
   if (configuration != null && typeof configuration === "string") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,21 +2,25 @@ import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { LazyOutputChannel, logger } from "./common/logger";
 import {
-  checkVersion,
-  initializePython,
-  onDidChangePythonInterpreter,
-  resolveInterpreter,
+  getEnvironmentProvider,
+  onDidChangeActivePythonEnvironment,
+  type OnDidChangeActivePythonEnvironmentEventArgs,
 } from "./common/python";
-import { startServer, stopServer } from "./common/server";
+import {
+  resolveServerPlan,
+  serverPlanKey,
+  type ServerState,
+  startServer,
+  stopServer,
+} from "./common/server";
 import {
   checkIfConfigurationChanged,
-  getInterpreterFromSetting,
   getWorkspaceSettings,
   ISettings,
   checkNotebookCodeActionsOnSave,
 } from "./common/settings";
 import { loadServerDefaults } from "./common/setup";
-import { registerLanguageStatusItem, updateStatus } from "./common/status";
+import { registerLanguageStatusItem } from "./common/status";
 import {
   getConfiguration,
   onDidChangeConfiguration,
@@ -31,12 +35,12 @@ import {
   createDebugInformationProvider,
 } from "./common/commands";
 
-let lsClient: LanguageClient | undefined;
-let restartInProgress = false;
+let serverState: ServerState | null = null;
 let restartQueued = false;
+let restartPromise: Promise<void> | null = null;
 
 function getClient(): LanguageClient | undefined {
-  return lsClient;
+  return serverState?.client;
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -78,100 +82,127 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return;
   }
 
-  if (restartInProgress) {
-    if (!restartQueued) {
-      // Schedule a new restart after the current restart.
-      logger.info(
-        `Triggered ${serverName} restart while restart is in progress; queuing a restart.`,
-      );
-      restartQueued = true;
-    }
-    return;
-  }
+  const environmentProvider = await getEnvironmentProvider();
 
   const runServer = async () => {
-    if (restartInProgress) {
+    if (serverState != null) {
+      await stopServer(serverState.client);
+      serverState = null;
+    }
+
+    const projectRoot = await getProjectRoot();
+    const workspaceSettings = await getWorkspaceSettings(serverId, projectRoot);
+    serverState = await startServer(
+      projectRoot,
+      workspaceSettings,
+      serverId,
+      serverName,
+      outputChannel,
+      traceOutputChannel,
+      environmentProvider,
+    );
+  };
+
+  const requestRestart = async () => {
+    if (restartPromise != null) {
       if (!restartQueued) {
-        // Schedule a new restart after the current restart.
         logger.info(
-          `Triggered ${serverName} restart while restart is in progress; queuing a restart.`,
+          `${serverName} restart requested while another restart is in progress; queuing one more restart.`,
         );
         restartQueued = true;
       }
+      await restartPromise;
       return;
     }
 
-    restartInProgress = true;
-
-    try {
-      if (lsClient) {
-        await stopServer(lsClient);
+    restartQueued = false;
+    restartPromise = (async () => {
+      try {
+        do {
+          restartQueued = false;
+          await runServer();
+        } while (restartQueued);
+      } finally {
+        restartPromise = null;
       }
+    })();
+    await restartPromise;
+  };
 
-      const projectRoot = await getProjectRoot();
-      const workspaceSettings = await getWorkspaceSettings(serverId, projectRoot);
-
-      if (vscode.workspace.isTrusted) {
-        if (workspaceSettings.interpreter.length === 0) {
-          updateStatus(
-            vscode.l10n.t("Please select a Python interpreter."),
-            vscode.LanguageStatusSeverity.Error,
-          );
-          logger.error(
-            "Python interpreter missing:\r\n" +
-              "[Option 1] Select Python interpreter using the ms-python.python.\r\n" +
-              `[Option 2] Set an interpreter using "${serverId}.interpreter" setting.\r\n` +
-              "Please use Python 3.8 or greater.",
-          );
-          return;
-        }
-
-        logger.info(`Using interpreter: ${workspaceSettings.interpreter.join(" ")}`);
-        const resolvedEnvironment = await resolveInterpreter(workspaceSettings.interpreter);
-        if (resolvedEnvironment === undefined) {
-          updateStatus(
-            vscode.l10n.t("Python interpreter not found."),
-            vscode.LanguageStatusSeverity.Error,
-          );
-          logger.error(
-            "Unable to find any Python environment for the interpreter path:",
-            workspaceSettings.interpreter.join(" "),
-          );
-          return;
-        } else if (!checkVersion(resolvedEnvironment)) {
-          return;
-        }
-      }
-
-      lsClient = await startServer(
-        projectRoot,
-        workspaceSettings,
-        serverId,
-        serverName,
-        outputChannel,
-        traceOutputChannel,
-      );
-    } finally {
-      // Ensure that we reset the flag in case of an error, early return, or success.
-      restartInProgress = false;
-      if (restartQueued) {
-        restartQueued = false;
-        await runServer();
-      }
-    }
+  let activeEnvironmentChangePromise = Promise.resolve();
+  const enqueueActiveEnvironmentChange = (task: () => Promise<void>) => {
+    const current = activeEnvironmentChangePromise.then(task, task);
+    activeEnvironmentChangePromise = current.then(
+      () => undefined,
+      (error) => {
+        logger.error(`Failed to handle Python environment change: ${error}`);
+      },
+    );
+    return current;
   };
 
   context.subscriptions.push(
-    onDidChangePythonInterpreter(async () => {
-      await runServer();
-    }),
+    onDidChangeActivePythonEnvironment(
+      async (event: OnDidChangeActivePythonEnvironmentEventArgs) => {
+        await enqueueActiveEnvironmentChange(async () => {
+          logger.info(
+            `Selected Python interpreter for '${event.uri ?? "workspace"}' changed to '${event.path ?? "<unknown>"}'.`,
+          );
+
+          if (restartPromise != null) {
+            logger.debug(
+              `${serverName} restart is already in progress; waiting before checking the Python environment change.`,
+            );
+            await restartPromise;
+          }
+
+          const projectRoot = await getProjectRoot();
+          const affectsProjectRoot =
+            event.uri == null || event.uri.toString() === projectRoot.uri.toString();
+          if (!affectsProjectRoot) {
+            return;
+          }
+
+          if (serverState == null) {
+            await requestRestart();
+            return;
+          }
+
+          if (!serverState.plan.dependsOnActiveInterpreter) {
+            logger.debug(
+              "Ignoring Python environment change because server selection is independent of it.",
+            );
+            return;
+          }
+
+          const settings = await getWorkspaceSettings(serverId, projectRoot);
+          const activeEnvironment =
+            (await environmentProvider?.getActiveEnvironment(projectRoot.uri)) ?? null;
+          const nextPlan = await resolveServerPlan(
+            settings,
+            projectRoot,
+            serverId,
+            environmentProvider,
+            activeEnvironment,
+            false,
+          );
+
+          if (nextPlan == null || serverPlanKey(nextPlan) !== serverPlanKey(serverState.plan)) {
+            logger.info(`Restarting ${serverName} because its execution plan changed.`);
+            await requestRestart();
+          } else {
+            logger.debug("Python environment changed without changing the Ruff execution plan.");
+          }
+        });
+      },
+    ),
     onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
       if (checkIfConfigurationChanged(e, serverId)) {
-        await runServer();
+        await requestRestart();
       }
     }),
     onDidGrantWorkspaceTrust(async () => {
-      await runServer();
+      await requestRestart();
     }),
     registerCommand(`${serverId}.showLogs`, () => {
       logger.channel.show();
@@ -180,21 +211,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       outputChannel.show();
     }),
     registerCommand(`${serverId}.restart`, async () => {
-      await runServer();
+      await requestRestart();
     }),
     registerCommand(`${serverId}.executeAutofix`, async () => {
-      if (lsClient) {
-        await executeAutofix(lsClient, serverId);
+      if (serverState != null) {
+        await executeAutofix(serverState.client, serverId);
       }
     }),
     registerCommand(`${serverId}.executeFormat`, async () => {
-      if (lsClient) {
-        await executeFormat(lsClient, serverId);
+      if (serverState != null) {
+        await executeFormat(serverState.client, serverId);
       }
     }),
     registerCommand(`${serverId}.executeOrganizeImports`, async () => {
-      if (lsClient) {
-        await executeOrganizeImports(lsClient, serverId);
+      if (serverState != null) {
+        await executeOrganizeImports(serverState.client, serverId);
       }
     }),
     registerCommand(
@@ -206,22 +237,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   checkNotebookCodeActionsOnSave(serverId);
 
-  setImmediate(async () => {
-    if (vscode.workspace.isTrusted) {
-      const interpreter = getInterpreterFromSetting(serverId);
-      if (interpreter === undefined || interpreter.length === 0) {
-        logger.info(`Python extension loading`);
-        await initializePython(context.subscriptions);
-        logger.info(`Python extension loaded`);
-        return; // The `onDidChangePythonInterpreter` event will trigger the server start.
-      }
-    }
-    await runServer();
-  });
+  await environmentProvider?.initialize(context.subscriptions);
+  await requestRestart();
 }
 
 export async function deactivate(): Promise<void> {
-  if (lsClient) {
-    await stopServer(lsClient);
+  if (serverState != null) {
+    await stopServer(serverState.client);
+    serverState = null;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
   onDidChangeActivePythonEnvironment,
   type OnDidChangeActivePythonEnvironmentEventArgs,
 } from "./common/python";
-import { resolveServerExecution, type ServerState, startServer, stopServer } from "./common/server";
+import { resolveServer, type ServerState, startServer, stopServer } from "./common/server";
 import {
   checkIfConfigurationChanged,
   getWorkspaceSettings,
@@ -165,7 +165,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             return;
           }
 
-          if (!serverState.execution.dependsOnActiveInterpreter) {
+          if (!serverState.resolution.dependsOnActiveInterpreter) {
             logger.debug(
               "Ignoring Python environment change because server selection is independent of it.",
             );
@@ -175,7 +175,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           const settings = await getWorkspaceSettings(serverId, projectRoot);
           const activeEnvironment =
             (await environmentProvider?.getActiveEnvironment(projectRoot.uri)) ?? null;
-          const nextExecution = await resolveServerExecution(
+          const nextResolution = await resolveServer(
             settings,
             projectRoot,
             serverId,
@@ -184,11 +184,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             false,
           );
 
-          if (nextExecution == null || !isDeepStrictEqual(nextExecution, serverState.execution)) {
-            logger.info(`Restarting ${serverName} because its server execution changed.`);
+          if (
+            nextResolution == null ||
+            !isDeepStrictEqual(nextResolution, serverState.resolution)
+          ) {
+            logger.info(`Restarting ${serverName} because the resolved server changed.`);
             await requestRestart();
           } else {
-            logger.debug("Python environment changed without changing the server execution.");
+            logger.debug("Python environment changed without changing the resolved server.");
           }
         });
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { LazyOutputChannel, logger } from "./common/logger";
@@ -6,13 +7,7 @@ import {
   onDidChangeActivePythonEnvironment,
   type OnDidChangeActivePythonEnvironmentEventArgs,
 } from "./common/python";
-import {
-  resolveServerPlan,
-  serverPlanKey,
-  type ServerState,
-  startServer,
-  stopServer,
-} from "./common/server";
+import { resolveServerExecution, type ServerState, startServer, stopServer } from "./common/server";
 import {
   checkIfConfigurationChanged,
   getWorkspaceSettings,
@@ -106,6 +101,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const requestRestart = async () => {
     if (restartPromise != null) {
       if (!restartQueued) {
+        // Schedule one more restart after the current restart finishes.
         logger.info(
           `${serverName} restart requested while another restart is in progress; queuing one more restart.`,
         );
@@ -123,6 +119,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           await runServer();
         } while (restartQueued);
       } finally {
+        // Reset the promise after success, an early return, or an error.
         restartPromise = null;
       }
     })();
@@ -168,7 +165,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             return;
           }
 
-          if (!serverState.plan.dependsOnActiveInterpreter) {
+          if (!serverState.execution.dependsOnActiveInterpreter) {
             logger.debug(
               "Ignoring Python environment change because server selection is independent of it.",
             );
@@ -178,7 +175,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           const settings = await getWorkspaceSettings(serverId, projectRoot);
           const activeEnvironment =
             (await environmentProvider?.getActiveEnvironment(projectRoot.uri)) ?? null;
-          const nextPlan = await resolveServerPlan(
+          const nextExecution = await resolveServerExecution(
             settings,
             projectRoot,
             serverId,
@@ -187,11 +184,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             false,
           );
 
-          if (nextPlan == null || serverPlanKey(nextPlan) !== serverPlanKey(serverState.plan)) {
-            logger.info(`Restarting ${serverName} because its execution plan changed.`);
+          if (nextExecution == null || !isDeepStrictEqual(nextExecution, serverState.execution)) {
+            logger.info(`Restarting ${serverName} because its server execution changed.`);
             await requestRestart();
           } else {
-            logger.debug("Python environment changed without changing the Ruff execution plan.");
+            logger.debug("Python environment changed without changing the server execution.");
           }
         });
       },
@@ -238,7 +235,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   checkNotebookCodeActionsOnSave(serverId);
 
   await environmentProvider?.initialize(context.subscriptions);
-  await requestRestart();
+
+  setImmediate(async () => {
+    if (serverState == null && restartPromise == null) {
+      await requestRestart();
+    }
+  });
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -35,47 +35,35 @@ suite("Utils tests", () => {
   });
 
   test("Invalid configured interpreter falls back to the active environment", async () => {
-    const activeEnvironment = environment("/workspace/.venv/bin/python");
+    const activeEnvironment = environment("/workspace/.venv/bin/python", ["-X", "utf8"]);
     const provider = environmentProvider(null, activeEnvironment);
 
-    const native = await resolvePythonEnvironment(
-      ["/missing/python"],
+    const resolved = await resolvePythonEnvironment(
+      ["/missing/python", "-I"],
       "file:///workspace",
       provider,
       activeEnvironment,
-      true,
     );
-    assert.deepStrictEqual(native, {
+    assert.deepStrictEqual(resolved, {
       environment: activeEnvironment,
+      command: activeEnvironment.command,
       dependsOnActiveInterpreter: true,
-    });
-
-    const legacy = await resolvePythonEnvironment(
-      ["/missing/python"],
-      "file:///workspace",
-      provider,
-      activeEnvironment,
-      false,
-    );
-    assert.deepStrictEqual(legacy, {
-      environment: null,
-      dependsOnActiveInterpreter: false,
     });
   });
 
   test("Configured interpreter takes precedence over the active environment", async () => {
-    const configuredEnvironment = environment("/configured/python");
+    const configuredEnvironment = environment("/configured/python", ["-X", "utf8"]);
     const activeEnvironment = environment("/workspace/.venv/bin/python");
 
     const resolved = await resolvePythonEnvironment(
-      ["/configured/python"],
+      ["/configured/python", "-I"],
       "file:///workspace",
       environmentProvider(configuredEnvironment, activeEnvironment),
       activeEnvironment,
-      true,
     );
     assert.deepStrictEqual(resolved, {
       environment: configuredEnvironment,
+      command: { executable: "/configured/python", args: ["-X", "utf8", "-I"] },
       dependsOnActiveInterpreter: false,
     });
   });
@@ -104,9 +92,9 @@ suite("Utils tests", () => {
   });
 });
 
-function environment(executable: string): PythonEnvironmentDetails {
+function environment(executable: string, args: string[] = []): PythonEnvironmentDetails {
   return {
-    command: { executable, args: [] },
+    command: { executable, args },
     sysPrefix: executable,
     version: { major: 3, minor: 12, patch: 0 },
   };

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,5 +1,11 @@
 import * as assert from "assert";
-import { execFileShellModeRequired } from "../common/server";
+import type { EnvironmentProvider, PythonEnvironmentDetails } from "../common/python";
+import {
+  execFileShellModeRequired,
+  resolvePythonEnvironment,
+  serverPlanKey,
+  type ServerPlan,
+} from "../common/server";
 import { isWindows } from "./helper";
 
 suite("Utils tests", () => {
@@ -25,4 +31,94 @@ suite("Utils tests", () => {
       "Shell mode should be required for .bat files",
     );
   });
+
+  test("Invalid configured interpreter falls back to the active environment", async () => {
+    const activeEnvironment = environment("/workspace/.venv/bin/python");
+    const provider = environmentProvider(null, activeEnvironment);
+
+    const native = await resolvePythonEnvironment(
+      ["/missing/python"],
+      "file:///workspace",
+      provider,
+      activeEnvironment,
+      true,
+    );
+    assert.deepStrictEqual(native, {
+      environment: activeEnvironment,
+      dependsOnActiveInterpreter: true,
+    });
+
+    const legacy = await resolvePythonEnvironment(
+      ["/missing/python"],
+      "file:///workspace",
+      provider,
+      activeEnvironment,
+      false,
+    );
+    assert.deepStrictEqual(legacy, {
+      environment: null,
+      dependsOnActiveInterpreter: false,
+    });
+  });
+
+  test("Configured interpreter takes precedence over the active environment", async () => {
+    const configuredEnvironment = environment("/configured/python");
+    const activeEnvironment = environment("/workspace/.venv/bin/python");
+
+    const resolved = await resolvePythonEnvironment(
+      ["/configured/python"],
+      "file:///workspace",
+      environmentProvider(configuredEnvironment, activeEnvironment),
+      activeEnvironment,
+      true,
+    );
+    assert.deepStrictEqual(resolved, {
+      environment: configuredEnvironment,
+      dependsOnActiveInterpreter: false,
+    });
+  });
+
+  test("Server plan key includes executable version and interpreter arguments", () => {
+    const native: ServerPlan = {
+      kind: "native",
+      executable: { path: "/bin/ruff", version: { major: 1, minor: 0, patch: 0 } },
+      dependsOnActiveInterpreter: true,
+    };
+    const updatedNative: ServerPlan = {
+      ...native,
+      executable: { path: "/bin/ruff", version: { major: 1, minor: 1, patch: 0 } },
+    };
+    assert.notStrictEqual(serverPlanKey(native), serverPlanKey(updatedNative));
+
+    const legacy: ServerPlan = {
+      kind: "legacy",
+      interpreter: { executable: "/bin/python", args: [] },
+      autoRuffExecutable: null,
+      dependsOnActiveInterpreter: true,
+    };
+    const updatedLegacy: ServerPlan = {
+      ...legacy,
+      interpreter: { executable: "/bin/python", args: ["-I"] },
+    };
+    assert.notStrictEqual(serverPlanKey(legacy), serverPlanKey(updatedLegacy));
+  });
 });
+
+function environment(executable: string): PythonEnvironmentDetails {
+  return {
+    command: { executable, args: [] },
+    sysPrefix: executable,
+    version: { major: 3, minor: 12, patch: 0 },
+  };
+}
+
+function environmentProvider(
+  resolved: PythonEnvironmentDetails | null,
+  active: PythonEnvironmentDetails | null,
+): EnvironmentProvider {
+  return {
+    initialize: () => Promise.resolve(),
+    resolveInterpreter: () => Promise.resolve(resolved),
+    getActiveEnvironment: () => Promise.resolve(active),
+  };
+}

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,11 +1,13 @@
 import * as assert from "assert";
+import * as vscode from "vscode";
+import { BUNDLED_RUFF_EXECUTABLE } from "../common/constants";
 import type { EnvironmentProvider, PythonEnvironmentDetails } from "../common/python";
 import {
   execFileShellModeRequired,
+  findRuffBinaryPath,
   resolvePythonEnvironment,
-  serverPlanKey,
-  type ServerPlan,
 } from "../common/server";
+import type { ISettings } from "../common/settings";
 import { isWindows } from "./helper";
 
 suite("Utils tests", () => {
@@ -78,29 +80,27 @@ suite("Utils tests", () => {
     });
   });
 
-  test("Server plan key includes executable version and interpreter arguments", () => {
-    const native: ServerPlan = {
-      kind: "native",
-      executable: { path: "/bin/ruff", version: { major: 1, minor: 0, patch: 0 } },
-      dependsOnActiveInterpreter: true,
-    };
-    const updatedNative: ServerPlan = {
-      ...native,
-      executable: { path: "/bin/ruff", version: { major: 1, minor: 1, patch: 0 } },
-    };
-    assert.notStrictEqual(serverPlanKey(native), serverPlanKey(updatedNative));
+  test("path and useBundled do not resolve a Python environment", async () => {
+    assert.strictEqual(vscode.workspace.isTrusted, true);
 
-    const legacy: ServerPlan = {
-      kind: "legacy",
-      interpreter: { executable: "/bin/python", args: [] },
-      autoRuffExecutable: null,
-      dependsOnActiveInterpreter: true,
-    };
-    const updatedLegacy: ServerPlan = {
-      ...legacy,
-      interpreter: { executable: "/bin/python", args: ["-I"] },
-    };
-    assert.notStrictEqual(serverPlanKey(legacy), serverPlanKey(updatedLegacy));
+    for (const settings of [
+      { path: [BUNDLED_RUFF_EXECUTABLE], importStrategy: "fromEnvironment" },
+      { path: [], importStrategy: "useBundled" },
+    ]) {
+      const resolution = await findRuffBinaryPath(
+        settings as ISettings,
+        {
+          ...environmentProvider(null, null),
+          resolveInterpreter: () => Promise.reject(new Error("unexpected interpreter lookup")),
+        },
+        null,
+      );
+
+      assert.deepStrictEqual(resolution, {
+        path: BUNDLED_RUFF_EXECUTABLE,
+        dependsOnActiveInterpreter: false,
+      });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Add dedicated support for the Python Environment Extension

This is mostly a back port from ty-vscode. The main difference is that we need to support ruff-lsp. 

This PR also changes our fallback behavior for the native server. We'll no longer block if the user hasn't selected an interpreter or if it's too old. For those cases, we now fallback to searching PATH and, ultimately, using the bundled executable. 

Closes https://github.com/astral-sh/ruff-vscode/issues/1029
Closes https://github.com/astral-sh/ruff-vscode/issues/598

## Test plan

I tested the interpreter selection with and without the Python environment extension. I verified that the server no longer restarts when using a fixed `ruff.path` (because the interpreter selection is then meaningless). I also tested ruff-lsp. 