### PR TITLE
Substitute `${env:X}` with an empty string for unset environment variables

### DIFF
--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -90,10 +90,7 @@ function resolveVariables(
   value: string | string[],
   workspace?: WorkspaceFolder,
 ): string | string[] | null {
-  const substitutions = new Map<
-    string | RegExp,
-    string | ((substr: string, ...args: any[]) => string)
-  >();
+  const substitutions = new Map<string, string>();
   const home = process.env.HOME || process.env.USERPROFILE;
   if (home) {
     substitutions.set("${userHome}", home);
@@ -105,30 +102,17 @@ function resolveVariables(
   getWorkspaceFolders().forEach((w) => {
     substitutions.set("${workspaceFolder:" + w.name + "}", w.uri.fsPath);
   });
-  // Replace ${env:*} with the environment variable value.
-  substitutions.set(/\${env:([^}]+)}/g, (_substr: string, envName: string): string => {
-    return process.env[envName] ?? "";
-  });
-
   const doSubstitutions = (s: string): string => {
-    let result = s;
     for (const [key, value] of substitutions) {
-      // This if-statement is needed since TypeScript cannot resolve unions against function
-      // overloads, even though both branches do the same thing.
-      if (typeof value === "string") {
-        result = result.replace(key, value);
-      } else {
-        result = result.replace(key, value);
-      }
+      s = s.replace(key, value);
     }
-    return result;
+    return s.replace(/\${env:([^}]+)}/g, (_match, envName) => {
+      const envValue = process.env[envName];
+      return typeof envValue === "string" ? envValue : "";
+    });
   };
 
-  if (typeof value === "string") {
-    return doSubstitutions(value);
-  } else {
-    return value.map(doSubstitutions);
-  }
+  return typeof value === "string" ? doSubstitutions(value) : value.map(doSubstitutions);
 }
 
 export function getInterpreterFromSetting(namespace: string, scope?: ConfigurationScope) {

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -90,7 +90,10 @@ function resolveVariables(
   value: string | string[],
   workspace?: WorkspaceFolder,
 ): string | string[] | null {
-  const substitutions = new Map<string, string>();
+  const substitutions = new Map<
+    string | RegExp,
+    string | ((substr: string, ...args: any[]) => string)
+  >();
   const home = process.env.HOME || process.env.USERPROFILE;
   if (home) {
     substitutions.set("${userHome}", home);
@@ -102,25 +105,29 @@ function resolveVariables(
   getWorkspaceFolders().forEach((w) => {
     substitutions.set("${workspaceFolder:" + w.name + "}", w.uri.fsPath);
   });
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined) {
-      substitutions.set("${env:" + key + "}", value);
+  // Replace ${env:*} with the environment variable value.
+  substitutions.set(/\${env:([^}]+)}/g, (_substr: string, envName: string): string => {
+    return process.env[envName] ?? "";
+  });
+
+  const doSubstitutions = (s: string): string => {
+    let result = s;
+    for (const [key, value] of substitutions) {
+      // This if-statement is needed since TypeScript cannot resolve unions against function
+      // overloads, even though both branches do the same thing.
+      if (typeof value === "string") {
+        result = result.replace(key, value);
+      } else {
+        result = result.replace(key, value);
+      }
     }
-  }
+    return result;
+  };
 
   if (typeof value === "string") {
-    let s = value;
-    for (const [key, value] of substitutions) {
-      s = s.replace(key, value);
-    }
-    return s;
+    return doSubstitutions(value);
   } else {
-    return value.map((s) => {
-      for (const [key, value] of substitutions) {
-        s = s.replace(key, value);
-      }
-      return s;
-    });
+    return value.map(doSubstitutions);
   }
 }
 


### PR DESCRIPTION
## Summary

Change how `${env:X}` blocks are handled so that if the variable `X` is not set, the block is replaced with an empty string, rather than the existing behavior of leaving the entire `${env:X}` block unsubstituted.

This makes this extension more consistent with the behavior of VSCode itself when parsing `${env:X}` blocks (it substitutes an empty string for unset variables). You can observe VSCode's behavior by, for example, creating a task like `{"type":"shell", "label": "echo var", "command": "echo '(${env:SOME_UNSET_VAR})'"}` and seeing that it outputs `()`.

## Test Plan

Set `"ruff.interpreter": [ "${env:SOME_UNSET_VAR}/b" ]` in extension settings. Observed log `Using interpreter: /b` (The previous behavior was `Using interpreter: ${env:SOME_UNSET_VAR}/b`)

Set `"ruff.interpreter": [ "${env:HOME}/b" ]` in extension settings. Observed log `Using interpreter: /home/myname/b` (existing behavior)
