### PR TITLE
Avoid blocking activation on Python environment discovery

### DIFF
--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -165,7 +165,8 @@ class PythonEnvironmentExtension implements EnvironmentProvider {
   async initialize(disposables: Disposable[]): Promise<void> {
     logger.info("Using Python Environments extension for Python environment detection");
 
-    await this.getActiveEnvironment(undefined);
+    // Server startup resolves the project environment. Avoid a global lookup here because it can
+    // trigger full environment discovery and block extension activation.
 
     disposables.push(
       this.#extension.onDidChangeEnvironment((event) => {


### PR DESCRIPTION
## Summary

Avoid resolving the global Python environment while initializing the provider. The lookup can trigger full environment discovery and block activation; server startup already resolves the project-scoped environment.

I added the global resolve, when I tried to avoid unnecessary server restarts. And removing the eager resolve does now show an unnecessary server restart in the logs. However, I've also given up on trying to deduplicate all Python Environment extension events, and have since migrated to a model where we detect unnecessary restart events (because all settings resolve to the same values). That's why I think this check is no longer necessary. 

We'll see if there are also situations where a `getEnvironment(path)` call later blocks.

Closes #1079.

## Test Plan

I tested the Python environment extension integration. But I don't have a good way of testing whether this indeed fixes #1079, because I haven't been able to reproduce this myself.
