### PR TITLE
Add `--skip-duplicate` to `vsce` and `ovsx publish` steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,10 +239,10 @@ jobs:
       # Publish to the Code Marketplace.
       - name: Publish Extension (Code Marketplace, release)
         if: "startsWith(github.ref, 'refs/tags/')"
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ruff-*.vsix
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ruff-*.vsix --skip-duplicate
       - name: Publish Extension (Code Marketplace, nightly)
         if: "!startsWith(github.ref, 'refs/tags/')"
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ruff-*.vsix --pre-release
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ruff-*.vsix --pre-release --skip-duplicate
 
   publish-openvsx:
     name: "Publish (OpenVSX)"
@@ -305,9 +305,9 @@ jobs:
       # Publish to OpenVSX.
       - name: Publish Extension (OpenVSX, release)
         if: "startsWith(github.ref, 'refs/tags/')"
-        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ruff-*.vsix
+        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ruff-*.vsix --skip-duplicate
         timeout-minutes: 2
       - name: Publish Extension (OpenVSX, nightly)
         if: "!startsWith(github.ref, 'refs/tags/')"
-        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ruff-*.vsix --pre-release
+        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ruff-*.vsix --pre-release --skip-duplicate
         timeout-minutes: 2


### PR DESCRIPTION
Summary
--

A couple of releases lately have failed while uploading artifacts to the marketplace, for example:

https://github.com/astral-sh/ruff-vscode/actions/runs/29048736946/attempts/1

Rerunning the failed jobs through GitHub doesn't work because some of the artifacts already exist:

https://github.com/astral-sh/ruff-vscode/actions/runs/29048736946

This PR adds the `--skip-duplicate` to allow retries to work. I didn't find this in the [documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#vsce), but Codex suggested it, and I then found it in the source code for both [vsce](https://github.com/microsoft/vscode-vsce/blob/9c562e733dc9746ac4858cfbbeb6766a0c3200f1/src/main.ts#L253) and [ovsx](https://github.com/eclipse-openvsx/openvsx/blob/0b10ee542a1c03735a3366910464bbfd03585e04/cli/src/main.ts#L55).

Test Plan
--

Retry the next release that times out
