### PR TITLE
Make the Python extension an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,7 @@ Finally, to use a common Ruff configuration across all projects, consider creati
 
 ## Requirements
 
-This extension requires a version of the VSCode Python extension that supports Python 3.8+. Ruff
-itself is compatible with Python 3.7 to 3.13.
+This extension requires VS Code 1.100 or later for Python Environments extension support.
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "webpack-cli": "^7.0.0"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.100.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ruff"
   ],
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.100.0"
   },
   "categories": [
     "Programming Languages",
@@ -37,7 +37,7 @@
     "Formatters"
   ],
   "extensionDependencies": [
-    "ms-python.python"
+    "ms-python.vscode-python-envs"
   ],
   "capabilities": {
     "untrustedWorkspaces": {


### PR DESCRIPTION
Summary
--

I mostly deferred to Codex here, hopefully I'm not missing anything too obvious.

The VS Code version bump is because Codex found that the 1.0 version of the Python Environments extension required VS Code 1.100:

https://github.com/microsoft/vscode-python-environments/blob/c46d4bd1264d3d55d4a8ac09d13836a9c963617c/package.json#L5-L9

Test plan
--

Also not sure how helpful this is, but I asked Codex to create a demo video:



https://github.com/user-attachments/assets/4a93a5e0-8005-4e86-b2d8-363f5d087c25

I believe this closes #479. Hopefully this will also address https://github.com/astral-sh/ruff-vscode/issues/943, but I'm not brave enough to mark it as closing that yet.