### PR TITLE
Revert dependency on Python Environments extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,19 +379,8 @@ Finally, to use a common Ruff configuration across all projects, consider creati
 
 ## Requirements
 
-This extension requires VS Code 1.100 or later for Python Environments extension support.
-
-To use the [VS Code Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-for Python environment detection instead, install the Python extension, add the following to your User Settings,
-and reload VS Code:
-
-```json
-{
-  "python.useEnvironmentsExtension": false
-}
-```
-
-The Python Environments extension must remain installed and enabled, since Ruff requires it to activate.
+This extension requires a version of the VSCode Python extension that supports Python 3.8+. Ruff
+itself is compatible with Python 3.7 to 3.13.
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "webpack-cli": "^7.0.0"
       },
       "engines": {
-        "vscode": "^1.100.0"
+        "vscode": "^1.75.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ruff"
   ],
   "engines": {
-    "vscode": "^1.100.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Programming Languages",
@@ -37,7 +37,7 @@
     "Formatters"
   ],
   "extensionDependencies": [
-    "ms-python.vscode-python-envs"
+    "ms-python.python"
   ],
   "capabilities": {
     "untrustedWorkspaces": {


### PR DESCRIPTION
Summary
--

This PR reverts #1110 and #1111, restoring our dependency on `ms-python.python` and removing the
dependency on `ms-python.vscode-python-envs`. This is one way of resolving #1114, but I'm going to
leave that open to follow up on trying to drop both dependencies instead.
