### PR TITLE
Make both Python extensions optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ The extension ships with `ruff==0.16.0`.
 
 ![Using the "Organize Imports" action to sort and deduplicate Python imports](https://user-images.githubusercontent.com/1309177/205175987-82e23e21-14bb-467d-9ef0-027f24b75865.gif)
 
+## Requirements
+
+This extension does not _require_ any additional extensions to function, but we recommend installing
+either of the following:
+
+- The VS Code [Python Environments
+  extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs). Note
+  that this requires VS Code 1.100 or later.
+- A version of the VSCode [Python
+  extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) that supports
+  Python 3.8+.
+
+When either of these is available, the Ruff extension uses it to locate the Ruff binary in the
+active environment. If no binary is found there, or both extensions are unavailable, Ruff falls back
+to the Ruff binary found on the `PATH` or bundled with the extension.
+
 ## Usage
 
 Once installed in Visual Studio Code, `ruff` will automatically execute when you open or edit a
@@ -376,11 +392,6 @@ Finally, to use a common Ruff configuration across all projects, consider creati
 | Ruff: Print debug information (native server only) | Print debug information about the native server |
 | Ruff: Show client logs                             | Open the Ruff output channel                    |
 | Ruff: Show server logs                             | Open the Ruff Language Server output channel    |
-
-## Requirements
-
-This extension requires a version of the VSCode Python extension that supports Python 3.8+. Ruff
-itself is compatible with Python 3.7 to 3.13.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ When either of these is available, the Ruff extension uses it to locate the Ruff
 active environment. If no binary is found there, or both extensions are unavailable, Ruff falls back
 to the Ruff binary found on the `PATH` or bundled with the extension.
 
+Note that the deprecated `ruff-lsp` server requires one of these extensions to locate a Python
+interpreter. If neither is installed, Ruff uses its native server instead. Reload VS Code after
+installing either extension to enable Python environment detection.
+
 ## Usage
 
 Once installed in Visual Studio Code, `ruff` will automatically execute when you open or edit a

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "Linters",
     "Formatters"
   ],
-  "extensionDependencies": [
-    "ms-python.python"
-  ],
+  "extensionDependencies": [],
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": "limited",
@@ -278,7 +276,7 @@
         },
         "ruff.interpreter": {
           "default": [],
-          "markdownDescription": "Path to a Python interpreter to use to find the `ruff` executable.",
+          "markdownDescription": "Path to a Python interpreter to use to find the `ruff` executable. Requires either the Python Environments or Python extension to be installed.",
           "scope": "resource",
           "items": {
             "type": "string"

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -1,11 +1,18 @@
 import { isDeepStrictEqual } from "node:util";
 import { type Disposable, type Event, EventEmitter, extensions, Uri } from "vscode";
 import {
+  PVSC_EXTENSION_ID,
   PythonExtension as PythonExtensionApi,
   type ResolvedEnvironment,
 } from "@vscode/python-extension";
-import type { PythonEnvironment, PythonEnvironmentApi } from "@vscode/python-environments";
+import {
+  EXTENSION_ID as PYTHON_ENVIRONMENTS_EXTENSION_ID,
+  type PythonEnvironment,
+  type PythonEnvironmentApi,
+} from "@vscode/python-environments";
 import { logger } from "./logger";
+
+export { PVSC_EXTENSION_ID, PYTHON_ENVIRONMENTS_EXTENSION_ID };
 
 const onDidChangeActivePythonEnvironmentEvent =
   new EventEmitter<OnDidChangeActivePythonEnvironmentEventArgs>();
@@ -63,7 +70,7 @@ class PythonExtension implements EnvironmentProvider {
   }
 
   static async tryActivate(): Promise<PythonExtension | null> {
-    if (extensions.getExtension("ms-python.python") == null) {
+    if (extensions.getExtension(PVSC_EXTENSION_ID) == null) {
       logger.info("The Python extension is not installed or is disabled.");
       return null;
     }
@@ -138,7 +145,7 @@ class PythonEnvironmentExtension implements EnvironmentProvider {
   }
 
   static async tryActivate(): Promise<PythonEnvironmentExtension | null> {
-    const extension = extensions.getExtension("ms-python.vscode-python-envs");
+    const extension = extensions.getExtension(PYTHON_ENVIRONMENTS_EXTENSION_ID);
 
     if (extension == null) {
       logger.info("The Python Environments extension is not installed or is disabled.");

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -63,6 +63,11 @@ class PythonExtension implements EnvironmentProvider {
   }
 
   static async tryActivate(): Promise<PythonExtension | null> {
+    if (extensions.getExtension("ms-python.python") == null) {
+      logger.info("The Python extension is not installed or is disabled.");
+      return null;
+    }
+
     logger.info("Initializing Python extension");
 
     try {

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -1,7 +1,7 @@
 import { isDeepStrictEqual } from "node:util";
 import { type Disposable, type Event, EventEmitter, extensions, Uri } from "vscode";
 import {
-  PVSC_EXTENSION_ID,
+  PVSC_EXTENSION_ID as PYTHON_EXTENSION_ID,
   PythonExtension as PythonExtensionApi,
   type ResolvedEnvironment,
 } from "@vscode/python-extension";
@@ -12,7 +12,7 @@ import {
 } from "@vscode/python-environments";
 import { logger } from "./logger";
 
-export { PVSC_EXTENSION_ID, PYTHON_ENVIRONMENTS_EXTENSION_ID };
+export { PYTHON_EXTENSION_ID, PYTHON_ENVIRONMENTS_EXTENSION_ID };
 
 const onDidChangeActivePythonEnvironmentEvent =
   new EventEmitter<OnDidChangeActivePythonEnvironmentEventArgs>();
@@ -70,7 +70,7 @@ class PythonExtension implements EnvironmentProvider {
   }
 
   static async tryActivate(): Promise<PythonExtension | null> {
-    if (extensions.getExtension(PVSC_EXTENSION_ID) == null) {
+    if (extensions.getExtension(PYTHON_EXTENSION_ID) == null) {
       logger.info("The Python extension is not installed or is disabled.");
       return null;
     }

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -444,6 +444,17 @@ async function resolveNativeServerSetting(
         return { useNativeServer: true };
       }
 
+      if (environmentProvider == null) {
+        const message =
+          `Cannot use the legacy server ([ruff-lsp](${RUFF_LSP_URL})) without the Python ` +
+          "Environments or Python extension; switching to the native server. Install one of " +
+          "these extensions and reload VS Code to use the legacy server.";
+        if (showWarnings) {
+          showWarningMessage(message);
+        }
+        return { useNativeServer: true };
+      }
+
       // User has explicitly set the native server to 'off'. Recommend them to upgrade to the native server ...
       let message =
         `The legacy server ([ruff-lsp](${RUFF_LSP_URL})) has been deprecated. ` +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,8 @@ import { LazyOutputChannel, logger } from "./common/logger";
 import {
   getEnvironmentProvider,
   onDidChangeActivePythonEnvironment,
+  PVSC_EXTENSION_ID,
+  PYTHON_ENVIRONMENTS_EXTENSION_ID,
   type OnDidChangeActivePythonEnvironmentEventArgs,
 } from "./common/python";
 import { resolveServer, type ServerState, startServer, stopServer } from "./common/server";
@@ -97,9 +99,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         .then((selection) => {
           const extensionId =
             selection === "Python Environments"
-              ? "ms-python.vscode-python-envs"
+              ? PYTHON_ENVIRONMENTS_EXTENSION_ID
               : selection === "Python"
-                ? "ms-python.python"
+                ? PVSC_EXTENSION_ID
                 : undefined;
 
           if (extensionId != null) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const message =
       "No Python environment extension is available. Ruff will use a configured, globally " +
       "installed, or bundled executable. Install the Python Environments or Python " +
-      "extension to enable Python environment detection.";
+      "extension to load a Ruff binary from the activated Python environment, then reload " +
+      "VS Code. [Learn more](https://github.com/astral-sh/ruff-vscode#requirements).";
 
     logger.info(message);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,6 +79,39 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const environmentProvider = await getEnvironmentProvider();
 
+  if (environmentProvider == null) {
+    const message =
+      "No Python environment extension is available. Ruff will use a configured, globally " +
+      "installed, or bundled executable. Install the Python Environments or Python " +
+      "extension to enable Python environment detection.";
+
+    logger.info(message);
+
+    const stateKey = "ruff.pythonEnvironmentRecommendationShown";
+
+    if (!context.globalState.get<boolean>(stateKey)) {
+      await context.globalState.update(stateKey, true);
+
+      void vscode.window
+        .showInformationMessage(message, "Python Environments", "Python")
+        .then((selection) => {
+          const extensionId =
+            selection === "Python Environments"
+              ? "ms-python.vscode-python-envs"
+              : selection === "Python"
+                ? "ms-python.python"
+                : undefined;
+
+          if (extensionId != null) {
+            void vscode.commands.executeCommand(
+              "workbench.extensions.search",
+              `@id:${extensionId}`,
+            );
+          }
+        });
+    }
+  }
+
   const runServer = async () => {
     if (serverState != null) {
       await stopServer(serverState.client);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { LazyOutputChannel, logger } from "./common/logger";
 import {
   getEnvironmentProvider,
   onDidChangeActivePythonEnvironment,
-  PVSC_EXTENSION_ID,
+  PYTHON_EXTENSION_ID,
   PYTHON_ENVIRONMENTS_EXTENSION_ID,
   type OnDidChangeActivePythonEnvironmentEventArgs,
 } from "./common/python";
@@ -102,7 +102,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             selection === "Python Environments"
               ? PYTHON_ENVIRONMENTS_EXTENSION_ID
               : selection === "Python"
-                ? PVSC_EXTENSION_ID
+                ? PYTHON_EXTENSION_ID
                 : undefined;
 
           if (extensionId != null) {

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -5,6 +5,7 @@ import type { EnvironmentProvider, PythonEnvironmentDetails } from "../common/py
 import {
   execFileShellModeRequired,
   findRuffBinaryPath,
+  resolveServer,
   resolvePythonEnvironment,
 } from "../common/server";
 import type { ISettings } from "../common/settings";
@@ -66,6 +67,27 @@ suite("Utils tests", () => {
       command: { executable: "/configured/python", args: ["-X", "utf8", "-I"] },
       dependsOnActiveInterpreter: false,
     });
+  });
+
+  test("Explicit legacy server without a Python provider falls back to the native server", async () => {
+    const workspace = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(workspace, "A test workspace is required");
+
+    const resolution = await resolveServer(
+      {
+        nativeServer: "off",
+        path: [BUNDLED_RUFF_EXECUTABLE],
+        importStrategy: "useBundled",
+      } as ISettings,
+      workspace,
+      "ruff",
+      null,
+      null,
+      false,
+    );
+
+    assert.strictEqual(resolution?.kind, "native");
+    assert.strictEqual(resolution?.executable.path, BUNDLED_RUFF_EXECUTABLE);
   });
 
   test("path and useBundled do not resolve a Python environment", async () => {

--- a/src/testFixture/.vscode/settings.json
+++ b/src/testFixture/.vscode/settings.json
@@ -3,8 +3,8 @@
   "ruff.nativeServer": "on",
   "ruff.importStrategy": "useBundled",
 
-  // Ruff's extension depends on the Python extension which also provides a language server,
-  // so we need to disable the Python language server to avoid special casing in the tests.
+  // Ruff's extension optionally depends on the Python extension which also provides a language
+  // server, so we need to disable the Python language server to avoid special casing in the tests.
   "python.languageServer": "None",
 
   "[python]": {


### PR DESCRIPTION
Summary
--

This PR closes #1114 by removing the dependency on `ms-python.python` again, without replacing it
with `ms-python.vscode-python-envs`. I documented this in the README, in the preexisting
`Requirements` section, which I moved much closer to the top.

I also updated the logs when the Python extension is unavailable and added a warning notification
too.

Test Plan
--

Manual testing in VS Code, using this command:

<details><summary>Details</summary>
<p>

```console
cd /Users/brw/astral/ruff-vscode

npm run compile

RUFF_DEMO_DIR="$(mktemp -d /private/tmp/ruff-vscode-optional.XXXXXX)"

cp -R src/testFixture "$RUFF_DEMO_DIR/project"

printf '\nimport math\n' >> "$RUFF_DEMO_DIR/project/diagnostics.py"

'/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code' \
  --new-window \
  --skip-welcome \
  --disable-workspace-trust \
  --user-data-dir "$RUFF_DEMO_DIR/data" \
  --extensions-dir "$RUFF_DEMO_DIR/extensions" \
  --extensionDevelopmentPath=/Users/brw/astral/ruff-vscode \
  "$RUFF_DEMO_DIR/project" \
  "$RUFF_DEMO_DIR/project/diagnostics.py"
```

</p>
</details> 

This shows the initial notification window and also that the extension functions without either Python extension installed:

<img width="840" height="512" alt="Screenshot 2026-07-29 at 12 22 57" src="https://github.com/user-attachments/assets/515137ef-1765-419b-89f0-4c323c9c621b" />
