### PR TITLE
Remove outdated Markdown formatting preview requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,10 @@ And, for Jupyter Notebooks:
 }
 ```
 
-And for [Markdown code blocks](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting).
-Note that this currently reqiures enabling [preview mode](https://docs.astral.sh/ruff/preview/)
-which will change formatting results:
+And for [Markdown code blocks](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting):
 
 ```json
 {
-  "ruff.format.preview": true,
   "[markdown]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "charliermarsh.ruff"


### PR DESCRIPTION
## Summary

Remove the outdated claim that formatting Python code blocks in Markdown requires preview mode, along with the unnecessary `ruff.format.preview` setting from the example. Ruff 0.16.0 stabilized Markdown formatting and enables it by default.