### PR TITLE
Pass `--default-index` to uv invocations in `release.py`

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -221,11 +221,15 @@ def update_changelog(versions: RuffVersions) -> None:
 def lock_requirements() -> None:
     """Update this package's lockfiles."""
     Path("requirements.txt").unlink()
-    subprocess.run(["uv", "lock"], check=True)
+    subprocess.run(
+        ["uv", "lock", "--default-index", "https://pypi.org/simple"], check=True
+    )
     subprocess.run(
         [
             "uv",
             "export",
+            "--default-index",
+            "https://pypi.org/simple",
             "--format",
             "requirements-txt",
             "--no-dev",


### PR DESCRIPTION
Summary
--

Ran into some lockfile changes when doing the release today and this resolved the issue

Test Plan
--

Today's release
