### PR TITLE
Gate TOML support on the Ruff version

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -42,7 +42,7 @@ import {
   supportsStableNativeServer,
   NATIVE_SERVER_STABLE_VERSION,
 } from "./version";
-import { updateServerKind, updateStatus } from "./status";
+import { updateServerInfo, updateStatus } from "./status";
 import { getDocumentSelector } from "./utilities";
 import { execFile } from "child_process";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -653,7 +653,7 @@ async function createServer(
   initializationOptions: IInitializationOptions,
   resolution: ServerResolution,
 ): Promise<LanguageClient> {
-  updateServerKind(
+  updateServerInfo(
     resolution.kind === "native",
     resolution.kind === "native" ? resolution.executable.version : undefined,
   );

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -294,8 +294,8 @@ async function createNativeServer(
   };
 
   const clientOptions = {
-    // Register the server for python documents
-    documentSelector: getDocumentSelector(),
+    // Register the server for supported documents.
+    documentSelector: getDocumentSelector(ruffVersion),
     outputChannel,
     traceOutputChannel,
     revealOutputChannelOn: RevealOutputChannelOn.Never,
@@ -653,7 +653,10 @@ async function createServer(
   initializationOptions: IInitializationOptions,
   resolution: ServerResolution,
 ): Promise<LanguageClient> {
-  updateServerKind(resolution.kind === "native");
+  updateServerKind(
+    resolution.kind === "native",
+    resolution.kind === "native" ? resolution.executable.version : undefined,
+  );
   if (resolution.kind === "native") {
     return createNativeServer(
       settings,

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -42,7 +42,7 @@ import {
   supportsStableNativeServer,
   NATIVE_SERVER_STABLE_VERSION,
 } from "./version";
-import { updateServerInfo, updateStatus } from "./status";
+import { updateDocumentSelector, updateServerKind, updateStatus } from "./status";
 import { getDocumentSelector } from "./utilities";
 import { execFile } from "child_process";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -653,10 +653,7 @@ async function createServer(
   initializationOptions: IInitializationOptions,
   resolution: ServerResolution,
 ): Promise<LanguageClient> {
-  updateServerInfo(
-    resolution.kind === "native",
-    resolution.kind === "native" ? resolution.executable.version : undefined,
-  );
+  updateServerKind(resolution.kind === "native");
   if (resolution.kind === "native") {
     return createNativeServer(
       settings,
@@ -726,6 +723,7 @@ export async function startServer(
     },
     resolution,
   );
+  updateDocumentSelector(newLSClient.clientOptions.documentSelector ?? []);
   logger.info(`Server: Start requested.`);
 
   _disposables.push(

--- a/src/common/status.ts
+++ b/src/common/status.ts
@@ -1,11 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { LanguageStatusItem, Disposable, l10n, LanguageStatusSeverity } from "vscode";
+import {
+  LanguageStatusItem,
+  Disposable,
+  l10n,
+  LanguageStatusSeverity,
+  DocumentSelector,
+} from "vscode";
 import { createLanguageStatusItem } from "./vscodeapi";
 import { Command } from "vscode-languageclient";
 import { getDocumentSelector } from "./utilities";
-import { VersionInfo } from "./version";
 
 let _status: LanguageStatusItem | undefined;
 let _serverKind: "native" | "ruff-lsp" | undefined;
@@ -24,10 +29,13 @@ export function registerLanguageStatusItem(id: string, name: string, command: st
   };
 }
 
-export function updateServerInfo(native: boolean, ruffVersion?: VersionInfo): void {
+export function updateServerKind(native: boolean): void {
   _serverKind = native ? "native" : "ruff-lsp";
+}
+
+export function updateDocumentSelector(selector: DocumentSelector): void {
   if (_status) {
-    _status.selector = getDocumentSelector(ruffVersion);
+    _status.selector = selector;
   }
 }
 

--- a/src/common/status.ts
+++ b/src/common/status.ts
@@ -5,6 +5,7 @@ import { LanguageStatusItem, Disposable, l10n, LanguageStatusSeverity } from "vs
 import { createLanguageStatusItem } from "./vscodeapi";
 import { Command } from "vscode-languageclient";
 import { getDocumentSelector } from "./utilities";
+import { VersionInfo } from "./version";
 
 let _status: LanguageStatusItem | undefined;
 let _serverKind: "native" | "ruff-lsp" | undefined;
@@ -23,8 +24,11 @@ export function registerLanguageStatusItem(id: string, name: string, command: st
   };
 }
 
-export function updateServerKind(native: boolean): void {
+export function updateServerKind(native: boolean, ruffVersion?: VersionInfo): void {
   _serverKind = native ? "native" : "ruff-lsp";
+  if (_status) {
+    _status.selector = getDocumentSelector(ruffVersion);
+  }
 }
 
 export function updateStatus(

--- a/src/common/status.ts
+++ b/src/common/status.ts
@@ -24,7 +24,7 @@ export function registerLanguageStatusItem(id: string, name: string, command: st
   };
 }
 
-export function updateServerKind(native: boolean, ruffVersion?: VersionInfo): void {
+export function updateServerInfo(native: boolean, ruffVersion?: VersionInfo): void {
   _serverKind = native ? "native" : "ruff-lsp";
   if (_status) {
     _status.selector = getDocumentSelector(ruffVersion);

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import { Uri, WorkspaceFolder } from "vscode";
 import { DocumentSelector } from "vscode-languageclient";
 import { getWorkspaceFolders, isVirtualWorkspace } from "./vscodeapi";
+import { supportsToml, VersionInfo } from "./version";
 
 export async function getProjectRoot(): Promise<WorkspaceFolder> {
   const workspaces: readonly WorkspaceFolder[] = getWorkspaceFolders();
@@ -35,16 +36,23 @@ export async function getProjectRoot(): Promise<WorkspaceFolder> {
   }
 }
 
-export function getDocumentSelector(): DocumentSelector {
-  return isVirtualWorkspace()
-    ? [{ language: "python" }, { language: "markdown" }]
-    : [
-        { scheme: "file", language: "python" },
-        { scheme: "untitled", language: "python" },
-        { scheme: "vscode-notebook", language: "python" },
-        { scheme: "vscode-notebook-cell", language: "python" },
-        { scheme: "file", language: "markdown" },
-        { scheme: "untitled", language: "markdown" },
-        { scheme: "file", pattern: "**/{pyproject.toml,ruff.toml,.ruff.toml}" },
-      ];
+export function getDocumentSelector(ruffVersion?: VersionInfo): DocumentSelector {
+  if (isVirtualWorkspace()) {
+    return [{ language: "python" }, { language: "markdown" }];
+  }
+
+  const selector: DocumentSelector = [
+    { scheme: "file", language: "python" },
+    { scheme: "untitled", language: "python" },
+    { scheme: "vscode-notebook", language: "python" },
+    { scheme: "vscode-notebook-cell", language: "python" },
+    { scheme: "file", language: "markdown" },
+    { scheme: "untitled", language: "markdown" },
+  ];
+
+  if (ruffVersion != null && supportsToml(ruffVersion)) {
+    selector.push({ scheme: "file", pattern: "**/{pyproject.toml,ruff.toml,.ruff.toml}" });
+  }
+
+  return selector;
 }

--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -70,3 +70,15 @@ export const INLINE_CONFIGURATION_VERSION: VersionInfo = { major: 0, minor: 9, p
 export function supportsInlineConfiguration(version: VersionInfo): boolean {
   return versionGte(version, INLINE_CONFIGURATION_VERSION);
 }
+
+/**
+ * The minimum Ruff version required for TOML document support.
+ */
+export const TOML_SUPPORT_VERSION: VersionInfo = { major: 0, minor: 16, patch: 2 };
+
+/**
+ * Check if the given version of the Ruff executable supports TOML documents.
+ */
+export function supportsToml(version: VersionInfo): boolean {
+  return versionGte(version, TOML_SUPPORT_VERSION);
+}

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -9,9 +9,30 @@ import {
   resolvePythonEnvironment,
 } from "../common/server";
 import type { ISettings } from "../common/settings";
-import { isWindows } from "./helper";
+import { getDocumentSelector } from "../common/utilities";
+import { getDocumentUri, isWindows } from "./helper";
 
 suite("Utils tests", () => {
+  test("TOML documents are excluded before Ruff 0.16.2", async () => {
+    const document = await vscode.workspace.openTextDocument(getDocumentUri("pyproject.toml"));
+    const selector = getDocumentSelector({ major: 0, minor: 16, patch: 1 });
+
+    assert.strictEqual(vscode.languages.match(selector, document), 0);
+  });
+
+  test("TOML documents are included starting with Ruff 0.16.2", async () => {
+    const document = await vscode.workspace.openTextDocument(getDocumentUri("pyproject.toml"));
+    const selector = getDocumentSelector({ major: 0, minor: 16, patch: 2 });
+
+    assert.ok(vscode.languages.match(selector, document) > 0);
+  });
+
+  test("TOML documents are excluded without a native Ruff version", async () => {
+    const document = await vscode.workspace.openTextDocument(getDocumentUri("pyproject.toml"));
+
+    assert.strictEqual(vscode.languages.match(getDocumentSelector(), document), 0);
+  });
+
   test("Check execFile shell mode", () => {
     assert.strictEqual(
       execFileShellModeRequired("/use/random/python"),


### PR DESCRIPTION
## Summary

This PR gates TOML registration behind a Ruff version check to avoid the issue reported in https://github.com/astral-sh/ruff-vscode/pull/1127#discussion_r3862952453, where older versions of Ruff try to lint TOML files as Python code.

The version check uses 0.16.2 because that includes the formatting fix in https://github.com/astral-sh/ruff/pull/27332, in addition to the basic TOML support added to the LSP in https://github.com/astral-sh/ruff/pull/26862 (shipped in 0.16.1) and to the linter in https://github.com/astral-sh/ruff/pull/26772 (shipped in 0.15.22).

TOML files are also excluded when `ruff-lsp` is used.

## Test plan

Manual testing in VS Code:

<img width="649" height="496" alt="image" src="https://github.com/user-attachments/assets/735ae6c7-50a1-4d77-86b5-5d861c7a9bf5" />

No problem is detected now, but if I use the same executable with the published version of the extension, I reproduce the diagnostic from the comment.
