### PR TITLE
Support ruff.interpreter without a Python environment extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ either of the following:
   Python 3.8+.
 
 When either of these is available, the Ruff extension uses it to locate the Ruff binary in the
-active environment. If no binary is found there, or both extensions are unavailable, Ruff falls back
-to the Ruff binary found on the `PATH` or bundled with the extension.
+active environment. You can also set `ruff.interpreter` to a Python executable or environment
+directory without either extension. If no Ruff executable is found in a Python environment, the
+extension checks `PATH` before using its bundled executable.
 
 Note that the deprecated `ruff-lsp` server requires one of these extensions to locate a Python
 interpreter. If neither is installed, Ruff uses its native server instead. Reload VS Code after

--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
             "useBundled"
           ],
           "enumDescriptions": [
-            "Use `ruff` from environment, falling back to the bundled version if `ruff` is not found.",
+            "Look for `ruff` using the configured interpreter, or in the active Python environment when the Python Environments or Python extension is available. Fall back to `PATH`, then the bundled version.",
             "Always use the bundled version of `ruff`."
           ],
           "scope": "window",
@@ -284,7 +284,7 @@
         },
         "ruff.interpreter": {
           "default": [],
-          "markdownDescription": "Path to a Python interpreter to use to find the `ruff` executable. Requires either the Python Environments or Python extension to be installed.",
+          "markdownDescription": "Path to a Python executable or environment directory used to find the `ruff` executable. Python 3.8 or later is required. This setting works without the Python Environments or Python extension.",
           "scope": "resource",
           "items": {
             "type": "string"

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,6 +1,7 @@
 import * as fsapi from "fs-extra";
 import * as vscode from "vscode";
 import { platform } from "os";
+import { join } from "path";
 import { Disposable, l10n, LanguageStatusSeverity, OutputChannel } from "vscode";
 import { State, ShowMessageNotification, MessageType } from "vscode-languageclient";
 import {
@@ -91,6 +92,40 @@ async function getRuffVersion(executable: string): Promise<VersionInfo> {
   return { major, minor, patch };
 }
 
+async function resolvePythonExecutable(interpreterPath: string): Promise<string> {
+  const stats = await fsapi.stat(interpreterPath).catch(() => undefined);
+  if (stats?.isFile()) {
+    return interpreterPath;
+  }
+  if (!stats?.isDirectory()) {
+    throw new Error(`'${interpreterPath}' is not a file or directory.`);
+  }
+
+  // Match the Python extensions' native resolver, including MSYS2's bin layout on Windows.
+  // https://github.com/microsoft/python-environment-tools/blob/4b7a780391ec7d447689a740be5073fbd8968a3d/crates/pet-python-utils/src/executable.rs#L49-L75
+  const candidates =
+    platform() === "win32"
+      ? [
+          "Scripts/python.exe",
+          "Scripts/python3.exe",
+          "bin/python.exe",
+          "bin/python3.exe",
+          "python.exe",
+          "python3.exe",
+        ]
+      : ["bin/python", "bin/python3", "python", "python3"];
+
+  for (const candidate of candidates) {
+    const executable = join(interpreterPath, candidate);
+    const stats = await fsapi.stat(executable).catch(() => undefined);
+    if (stats?.isFile()) {
+      return executable;
+    }
+  }
+
+  throw new Error(`No Python executable found in '${interpreterPath}'.`);
+}
+
 /**
  * Finds the Ruff binary path and returns it.
  *
@@ -101,7 +136,8 @@ async function getRuffVersion(executable: string): Promise<VersionInfo> {
  *    executable path.
  * 3. Execute a Python script that tries to locate the binary. This uses either
  *    the user-provided interpreter or the interpreter provided by the Python
- *    extension.
+ *    extension. If no Python environment extension is available, the configured
+ *    interpreter is used directly.
  * 4. If the Python script doesn't return a path, check the global environment
  *    which checks the PATH environment variable.
  * 5. If all else fails, return the bundled executable path.
@@ -183,6 +219,26 @@ export async function findRuffBinaryPath(
   }
 
   // Otherwise, we'll call a Python script that tries to locate a binary.
+  const [configuredPath, ...configuredArgs] = settings.interpreter;
+  if (environmentProvider == null && configuredPath != null) {
+    logger.info(`Looking for Ruff using 'ruff.interpreter': '${configuredPath}'`);
+    try {
+      const executable = await resolvePythonExecutable(configuredPath);
+      logger.info(`Resolved Python executable for Ruff lookup: '${executable}'`);
+      const stdout = await executeFile(executable, [
+        ...configuredArgs,
+        FIND_RUFF_BINARY_SCRIPT_PATH,
+      ]);
+      const ruffBinaryPath = stdout.trim();
+      if (ruffBinaryPath.length > 0) {
+        logger.info(`Using the Ruff binary: ${ruffBinaryPath}`);
+        return { path: ruffBinaryPath, dependsOnActiveInterpreter: false };
+      }
+    } catch (err) {
+      logger.warn(`Could not find Ruff using 'ruff.interpreter': ${err}`);
+    }
+  }
+
   let ruffBinaryPath: string | undefined;
   const { environment, command, dependsOnActiveInterpreter } = await resolvePythonEnvironment(
     settings.interpreter,

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -56,6 +56,25 @@ suite("Utils tests", () => {
     );
   });
 
+  test("Configured interpreter finds Ruff without a Python provider", async () => {
+    const ruffPath = "/configured/ruff";
+    const resolution = await findRuffBinaryPath(
+      {
+        path: [],
+        importStrategy: "fromEnvironment",
+        interpreter: [process.execPath, "-e", `console.log(${JSON.stringify(ruffPath)})`, "--"],
+        workspace: "file:///workspace",
+      } as unknown as ISettings,
+      null,
+      null,
+    );
+
+    assert.deepStrictEqual(resolution, {
+      path: ruffPath,
+      dependsOnActiveInterpreter: false,
+    });
+  });
+
   test("Invalid configured interpreter falls back to the active environment", async () => {
     const activeEnvironment = environment("/workspace/.venv/bin/python", ["-X", "utf8"]);
     const provider = environmentProvider(null, activeEnvironment);


### PR DESCRIPTION
## Summary

`ruff.interpreter` was ignored when neither the Python Environments nor Python extension was
available because interpreter resolution returned early. Resolve a configured Python executable or
environment directory directly in that case, while preserving the existing provider-based lookup
and `PATH`/bundled fallbacks.

Update the setting documentation and add a regression test for discovery without an environment
provider.

Fixes #1128

## Test Plan

- `npm run check`
- `npm run package`
- Focused VS Code regression test: configured interpreter finds Ruff without a Python provider
- Windows integration with a real Python 3.10 virtual environment whose path contains spaces:
  executable plus arguments and environment-directory forms both passed
- Full VS Code suite: 10/11 passed; the remaining diagnostics expectation mismatch reproduces on
  the unmodified `main` baseline with bundled Ruff 0.16.6 and is unrelated to this change
